### PR TITLE
fix IndexError when no argv is given

### DIFF
--- a/h2olog.py
+++ b/h2olog.py
@@ -740,7 +740,7 @@ if len(sys.argv) < 1:
 
 tracer_func = trace_http
 optidx = 1
-if sys.argv[1] == "quic":
+if len(sys.argv) > 1 and sys.argv[1] == "quic":
     tracer_func = trace_quic
     optidx = 2
 


### PR DESCRIPTION
before:

```
$ python h2olog.py
Traceback (most recent call last):
  File "h2olog.py", line 743, in <module>
    if sys.argv[1] == "quic":
IndexError: list index out of range
```

after:

```
$ python h2olog.py
USAGE: h2olog -p PID
       h2olog quic -p PID
       h2olog quic -t event_type -p PID
```