### PR TITLE
make `h2olog` executable

### DIFF
--- a/h2olog
+++ b/h2olog
@@ -8,7 +8,11 @@
 
 from bcc import BPF, USDT
 from collections import OrderedDict
-import binascii, getopt, json, sys, time
+import binascii, getopt, json, sys, time, os
+
+# sudo itself if it is not running as root
+if os.geteuid() != 0:
+    os.execvp("sudo", ["-E", sys.executable] + sys.argv)
 
 bpf = """
 #define MAX_STR_LEN 128


### PR DESCRIPTION
Make it callable by just `h2olog` (or `./h2olog` on development):

* Remove `.py` ext not to concern about its implementation details
* `chmod +x h2olog`
* add "sudo itself" hack to make `sudo` optional
  * see https://github.com/h2o/h2o/blob/master/t/Util.pm#L29-L33