### PR TITLE
[quic] add -v and -s to filter response headers

### DIFF
--- a/h2olog
+++ b/h2olog
@@ -857,8 +857,7 @@ if sys.argv[1] == "quic":
     u.enable_probe(probe="quictrace_recv", fn_name="trace_quictrace_recv")
     u.enable_probe(probe="quictrace_recv_ack_delay", fn_name="trace_quictrace_recv_ack_delay")
     u.enable_probe(probe="quictrace_lost", fn_name="trace_quictrace_lost")
-    if verbose:
-        u.enable_probe(probe="send_response_header", fn_name="trace_send_response_header")
+    u.enable_probe(probe="send_response_header", fn_name="trace_send_response_header")
     b = BPF(text=quic_bpf, usdt_contexts=[u])
 else:
     u.enable_probe(probe="receive_request", fn_name="trace_receive_req")

--- a/h2olog
+++ b/h2olog
@@ -710,6 +710,9 @@ def handle_quic_event(cpu, data, size):
     if allowed_quic_event and ev.type != allowed_quic_event:
         return
 
+    if allowed_res_header_name and ev.type == "send_response_header" and ev.h2o_header_name != allowed_res_header_name:
+        return
+
     res = OrderedDict()
     load_common_fields(res, ev)
 
@@ -767,9 +770,12 @@ def handle_quic_event(cpu, data, size):
     print(json.dumps(res, separators = (',', ':')))
 
 def usage():
-    print ("USAGE: h2olog -p PID")
-    print ("       h2olog quic -p PID")
-    print ("       h2olog quic -t event_type -p PID")
+    print("""
+USAGE: h2olog -p PID
+       h2olog quic -p PID
+       h2olog quic -t event_type -p PID
+       h2olog quic -v -s response_header_name -p PID
+""".strip())
     exit()
 
 def trace_http():
@@ -802,12 +808,19 @@ if len(sys.argv) > 1 and sys.argv[1] == "quic":
 try:
     h2o_pid = 0
     allowed_quic_event = None
-    opts, args = getopt.getopt(sys.argv[optidx:], 'p:t:')
+    allowed_res_header_name = None
+    verbose = False
+    opts, args = getopt.getopt(sys.argv[optidx:], 'vp:t:s:')
     for opt, arg in opts:
         if opt == "-p":
             h2o_pid = arg
-        if opt == "-t":
+        elif opt == "-t":
             allowed_quic_event = arg
+        elif opt == "-v":
+            verbose = True
+        elif opt == "-s": # reSponse
+            allowed_res_header_name = arg.lower()
+
 except getopt.error as msg:
     print(msg)
     sys.exit(2)
@@ -844,7 +857,8 @@ if sys.argv[1] == "quic":
     u.enable_probe(probe="quictrace_recv", fn_name="trace_quictrace_recv")
     u.enable_probe(probe="quictrace_recv_ack_delay", fn_name="trace_quictrace_recv_ack_delay")
     u.enable_probe(probe="quictrace_lost", fn_name="trace_quictrace_lost")
-    u.enable_probe(probe="send_response_header", fn_name="trace_send_response_header")
+    if verbose:
+        u.enable_probe(probe="send_response_header", fn_name="trace_send_response_header")
     b = BPF(text=quic_bpf, usdt_contexts=[u])
 else:
     u.enable_probe(probe="receive_request", fn_name="trace_receive_req")

--- a/h2olog
+++ b/h2olog
@@ -710,8 +710,11 @@ def handle_quic_event(cpu, data, size):
     if allowed_quic_event and ev.type != allowed_quic_event:
         return
 
-    if allowed_res_header_name and ev.type == "send_response_header" and ev.h2o_header_name != allowed_res_header_name:
-        return
+    if ev.type == "send_response_header": # HTTP-level events
+        if not verbose:
+            return
+        if allowed_res_header_name and ev.h2o_header_name != allowed_res_header_name:
+            return
 
     res = OrderedDict()
     load_common_fields(res, ev)
@@ -820,7 +823,6 @@ try:
             verbose = True
         elif opt == "-s": # reSponse
             allowed_res_header_name = arg.lower()
-
 except getopt.error as msg:
     print(msg)
     sys.exit(2)


### PR DESCRIPTION
As discussed in https://github.com/toru/h2olog/pull/17, I'd like to add `-v` to enable `send_response_header` probe and `-s` to filter it (`s` comes from re**S**ponse).