### PR TITLE
Use constant length to read from memory

### DIFF
--- a/h2olog
+++ b/h2olog
@@ -16,7 +16,6 @@ if os.geteuid() != 0:
 
 bpf = """
 #define MAX_STR_LEN 128
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 /*
  * "trace_line_t" is a general structure to store the data emitted by
@@ -59,14 +58,12 @@ int trace_receive_req_header(struct pt_regs *ctx) {
     // Extract the Header Name
     bpf_usdt_readarg(3, ctx, &pos);
     bpf_usdt_readarg(4, ctx, &line.header_name_len);
-    line.header_name_len = MIN(MAX_STR_LEN, line.header_name_len);
-    bpf_probe_read(&line.header_name, line.header_name_len, pos);
+    bpf_probe_read(&line.header_name, MAX_STR_LEN, pos);
 
     // Extract the Header Value
     bpf_usdt_readarg(5, ctx, &pos);
     bpf_usdt_readarg(6, ctx, &line.header_value_len);
-    line.header_value_len = MIN(MAX_STR_LEN, line.header_value_len);
-    bpf_probe_read(&line.header_value, line.header_value_len, pos);
+    bpf_probe_read(&line.header_value, MAX_STR_LEN, pos);
 
     if (rxbuf.perf_submit(ctx, &line, sizeof(line)) < 0)
         bpf_trace_printk("failed to perf_submit\\n");

--- a/h2olog
+++ b/h2olog
@@ -58,12 +58,12 @@ int trace_receive_req_header(struct pt_regs *ctx) {
     // Extract the Header Name
     bpf_usdt_readarg(3, ctx, &pos);
     bpf_usdt_readarg(4, ctx, &line.header_name_len);
-    bpf_probe_read(&line.header_name, MAX_STR_LEN, pos);
+    bpf_probe_read(&line.header_name, sizeof(line.header_name), pos);
 
     // Extract the Header Value
     bpf_usdt_readarg(5, ctx, &pos);
     bpf_usdt_readarg(6, ctx, &line.header_value_len);
-    bpf_probe_read(&line.header_value, MAX_STR_LEN, pos);
+    bpf_probe_read(&line.header_value, sizeof(line.header_value), pos);
 
     if (rxbuf.perf_submit(ctx, &line, sizeof(line)) < 0)
         bpf_trace_printk("failed to perf_submit\\n");

--- a/h2olog
+++ b/h2olog
@@ -680,7 +680,9 @@ def handle_req_line(cpu, data, size):
         v = "HTTP/%d.%d" % (line.http_version / 256, line.http_version % 256)
         print("%u %u RxProtocol %s" % (line.conn_id, line.req_id, v))
     else:
-        print("%u %u RxHeader   %s %s" % (line.conn_id, line.req_id, s(line.header_name), s(line.header_value)))
+        hn = line.header_name[:line.header_name_len]
+        hv = line.header_value[:line.header_value_len]
+        print("%u %u RxHeader   %s %s" % (line.conn_id, line.req_id, s(hn), s(hv)))
 
 def handle_resp_line(cpu, data, size):
     line = b["txbuf"].event(data)


### PR DESCRIPTION
Addresses #2. Verifiers in older kernels do not like it when a scalar is used to specify the length to copy.