### PR TITLE
Fix `h2olog quic` to handle only HTTP/3 events

### DIFF
--- a/h2olog
+++ b/h2olog
@@ -659,16 +659,22 @@ int trace_quicly__quictrace_lost(struct pt_regs *ctx) {
 }
 
 #ifdef ENABLE_H2O_PROBES
+BPF_HASH(h2o_to_quicly_conn, u64, u32);
+
 int trace_h2o__send_response_header(struct pt_regs *ctx) {
     void *pos = NULL;
     struct quic_event_t event = {};
     size_t name_len = 0;
     INIT_EVENT_NAME(event);
 
-    event.master_conn_id = 0;
     bpf_usdt_readarg(1, ctx, &event.h2o_conn_id);
-    bpf_usdt_readarg(2, ctx, &event.h2o_req_id);
 
+    const u32 *master_conn_id_ptr = h2o_to_quicly_conn.lookup(&event.h2o_conn_id);
+    if (master_conn_id_ptr == NULL)
+        return 0;
+    event.master_conn_id = *master_conn_id_ptr;
+
+    bpf_usdt_readarg(2, ctx, &event.h2o_req_id);
     bpf_usdt_readarg(3, ctx, &pos);
     bpf_usdt_readarg(4, ctx, &name_len);
     bpf_probe_read(&event.h2o_header_name, MAX_STR_LEN, pos);
@@ -701,6 +707,8 @@ int trace_h2o__h3_accept(struct pt_regs *ctx) {
     bpf_probe_read(&conn, sizeof(conn), pos);
     event.master_conn_id = conn.master_id;
 
+    h2o_to_quicly_conn.update(&event.h2o_conn_id, &event.master_conn_id);
+
     if (events.perf_submit(ctx, &event, sizeof(event)) < 0)
         bpf_trace_printk("failed to perf_submit\\n");
 
@@ -712,6 +720,14 @@ int trace_h2o__h3_close(struct pt_regs *ctx) {
     INIT_EVENT_NAME(event);
 
     bpf_usdt_readarg(1, ctx, &event.h2o_conn_id);
+
+    const u32 *master_conn_id_ptr = h2o_to_quicly_conn.lookup(&event.h2o_conn_id);
+    if (master_conn_id_ptr != NULL) {
+        event.master_conn_id = *master_conn_id_ptr;
+    } else {
+        bpf_trace_printk("h2o_conn_id=%lu is not associated to master_conn_id\\n", event.h2o_conn_id);
+    }
+    h2o_to_quicly_conn.delete(&event.h2o_conn_id);
 
     if (events.perf_submit(ctx, &event, sizeof(event)) < 0)
         bpf_trace_printk("failed to perf_submit\\n");
@@ -821,12 +837,10 @@ def handle_quic_event(cpu, data, size):
         build_quic_trace_result(res, ev, ["packet_num"])
     elif ev.type == "h2o__send_response_header":
         build_quic_trace_result(res, ev, ["h2o_conn_id", "h2o_req_id", "h2o_header_name", "h2o_header_value"])
-        del res["master_conn_id"]
     elif ev.type == "h2o__h3_accept":
         build_quic_trace_result(res, ev, ["h2o_conn_id"])
     elif ev.type == "h2o__h3_close":
         build_quic_trace_result(res, ev, ["h2o_conn_id"])
-        del res["master_conn_id"]
     else:
         raise Exception("Unknown event type: %s" % ev.type)
     print(json.dumps(res, separators = (',', ':')))


### PR DESCRIPTION
Because `h2o:send_response_header` is emitted for HTTP/1 and HTTP/2, it includes a lot of noise in `h2olog quic` to trace QUIC events. This PR filters these irrelevant events and add `master_conn_id` to H2O events.

There's a point to discuss: does adding `master_conn_id` to `h2o:h3_*` work? It is convinient but redundant.

What do you think of it?

<del>This is based on https://github.com/toru/h2olog/pull/30 and 9b8636d is the core logic. Will undraft it when #30 is merged.</del>

Example output:

```
{"at":1583822635155,"type":"quicly:accept","master_conn_id":2,"dcid":"d9662d283b2f942d"}
{"at":1583822635157,"type":"quicly:crypto_decrypt","master_conn_id":2,"packet_num":1583822635155,"len":140724314636156}
{"at":1583822635155,"type":"quicly:quictrace_recv","master_conn_id":2,"packet_num":0}
{"at":1583822635160,"type":"quicly:crypto_handshake","master_conn_id":2,"ret":0}
{"at":1583822635161,"type":"h2o:h3_accept","master_conn_id":2,"h2o_conn_id":7}
{"at":1583822635161,"type":"quicly:packet_prepare","master_conn_id":2,"first_octet":192,"dcid":"1909e140f9e23d57"}
{"at":1583822635161,"type":"quicly:packet_commit","master_conn_id":2,"packet_num":0,"packet_len":176,"ack_only":0}
{"at":1583822635161,"type":"quicly:quictrace_sent","master_conn_id":2,"packet_num":0,"packet_len":176,"packet_type":0}
{"at":1583822635161,"type":"quicly:packet_prepare","master_conn_id":2,"first_octet":224,"dcid":"1909e140f9e23d57"}
{"at":1583822635161,"type":"quicly:packet_commit","master_conn_id":2,"packet_num":1,"packet_len":1104,"ack_only":0}
{"at":1583822635161,"type":"quicly:quictrace_sent","master_conn_id":2,"packet_num":1,"packet_len":1280,"packet_type":2}
{"at":1583822635161,"type":"quicly:packet_prepare","master_conn_id":2,"first_octet":224,"dcid":"1909e140f9e23d57"}
{"at":1583822635161,"type":"quicly:packet_commit","master_conn_id":2,"packet_num":2,"packet_len":232,"ack_only":0}
{"at":1583822635161,"type":"quicly:quictrace_sent","master_conn_id":2,"packet_num":2,"packet_len":232,"packet_type":2}
{"at":1583822635161,"type":"quicly:packet_prepare","master_conn_id":2,"first_octet":64,"dcid":"1909e140f9e23d57"}
{"at":1583822635161,"type":"quicly:new_token_send","master_conn_id":2,"token_preview":"6f40017b9871b57a","len":46,"token_generation":1}
{"at":1583822635161,"type":"quicly:packet_commit","master_conn_id":2,"packet_num":3,"packet_len":89,"ack_only":0}
{"at":1583822635161,"type":"quicly:quictrace_sent","master_conn_id":2,"packet_num":3,"packet_len":321,"packet_type":3}
{"at":1583822635167,"type":"quicly:receive","master_conn_id":2,"dcid":"6fc605fb2907ce5cbc"}
{"at":1583822635168,"type":"quicly:crypto_decrypt","master_conn_id":2,"packet_num":1583822635167,"len":140724314636156}
{"at":1583822635167,"type":"quicly:quictrace_recv","master_conn_id":2,"packet_num":1}
{"at":1583822635167,"type":"quicly:packet_acked","master_conn_id":2,"packet_num":1,"newly_acked":1}
{"at":1583822635167,"type":"quicly:packet_acked","master_conn_id":2,"packet_num":2,"newly_acked":1}
{"at":1583822635167,"type":"quicly:quictrace_recv_ack_delay","master_conn_id":2,"ack_delay":0}
{"at":1583822635167,"type":"quicly:cc_ack_received","master_conn_id":2,"largest_acked":2,"bytes_acked":1336,"cwnd":14136,"inflight":89}
{"at":1583822635169,"type":"quicly:crypto_handshake","master_conn_id":2,"ret":0}
{"at":1583822635167,"type":"quicly:receive","master_conn_id":2,"dcid":"6fc605fb2907ce5cbc"}
{"at":1583822635169,"type":"quicly:crypto_decrypt","master_conn_id":2,"packet_num":1583822635167,"len":140724314636244}
{"at":1583822635167,"type":"quicly:quictrace_recv","master_conn_id":2,"packet_num":2}
{"at":1583822635167,"type":"quicly:packet_acked","master_conn_id":2,"packet_num":3,"newly_acked":1}
{"at":1583822635167,"type":"quicly:new_token_acked","master_conn_id":2,"token_generation":1}
{"at":1583822635167,"type":"quicly:quictrace_recv_ack_delay","master_conn_id":2,"ack_delay":0}
{"at":1583822635167,"type":"quicly:cc_ack_received","master_conn_id":2,"largest_acked":3,"bytes_acked":89,"cwnd":14225,"inflight":0}
{"at":1583822635170,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"content-length","h2o_header_value":"177"}
{"at":1583822635171,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"date","h2o_header_value":"Tue, 10 Mar 2020 06:43:55 GMT"}
{"at":1583822635171,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"content-type","h2o_header_value":"text/html"}
{"at":1583822635171,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"last-modified","h2o_header_value":"Mon, 10 Feb 2020 03:41:35 GMT"}
{"at":1583822635171,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"etag","h2o_header_value":"\"5e40d0ef-b1\""}
{"at":1583822635172,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"accept-ranges","h2o_header_value":"bytes"}
{"at":1583822635172,"type":"h2o:send_response_header","master_conn_id":2,"h2o_conn_id":7,"h2o_req_id":0,"h2o_header_name":"alt-svc","h2o_header_value":"h3-25=\":8081\""}
{"at":1583822635167,"type":"quicly:packet_prepare","master_conn_id":2,"first_octet":64,"dcid":"1909e140f9e23d57"}
{"at":1583822635167,"type":"quicly:packet_commit","master_conn_id":2,"packet_num":4,"packet_len":334,"ack_only":0}
{"at":1583822635167,"type":"quicly:quictrace_sent","master_conn_id":2,"packet_num":4,"packet_len":334,"packet_type":3}
{"at":1583822635168,"type":"quicly:receive","master_conn_id":2,"dcid":"6fc605fb2907ce5cbc"}
{"at":1583822635174,"type":"quicly:crypto_decrypt","master_conn_id":2,"packet_num":1583822635168,"len":140724314636140}
{"at":1583822635168,"type":"quicly:quictrace_recv","master_conn_id":2,"packet_num":4}
{"at":1583822635298,"type":"h2o:h3_close","master_conn_id":2,"h2o_conn_id":7}
```