### PR TITLE
First cut of a modular tracer structure

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -36,11 +36,13 @@ static void usage(void) {
 }
 
 int main(int argc, char **argv) {
-  bpf_cb cb = handle_http_event;
+  h2o_tracer_t *tracer;
   if (argc > 1 && strcmp(argv[1], "quic") == 0) {
-    cb = handle_quic_event;
+    tracer = create_quic_tracer();
     --argc;
     ++argv;
+  } else {
+    tracer = create_http_tracer();
   }
 
   int c;
@@ -80,7 +82,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  ret = bpf->open_perf_buffer("events", cb);
+  ret = bpf->open_perf_buffer("events", tracer->handle_event);
   if (ret.code() != 0) {
     std::cerr << ret.msg() << std::endl;
     return 1;

--- a/h2olog.cc
+++ b/h2olog.cc
@@ -63,10 +63,8 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  std::vector<ebpf::USDT> probes;
   ebpf::BPF *bpf = new ebpf::BPF();
-  probes.push_back(ebpf::USDT(h2o_pid, "quicly", "accept", "trace_quicly__accept"));
-  probes.push_back(ebpf::USDT(h2o_pid, "quicly", "crypto_handshake", "trace_quicly__crypto_handshake"));
+  std::vector<ebpf::USDT> probes = tracer->init_usdt_probes(h2o_pid);
 
   ebpf::StatusTuple ret = bpf->init(QUIC_BPF, {}, probes);
   if (!ret.ok()) {

--- a/h2olog.h
+++ b/h2olog.h
@@ -25,6 +25,7 @@
 
 #include <inttypes.h>
 #include <bcc/BPF.h>
+#include <vector>
 
 extern const char *HTTP_BPF;
 extern const char *QUIC_BPF;
@@ -34,9 +35,14 @@ typedef struct st_h2o_tracer_t {
    * Handles an incoming BPF event.
    */
   void (*handle_event)(void *cpu, void *data, int len);
-} h2o_tracer_t;
-/*
 
+  /*
+   * Returns a vector of relevant USDT probes.
+   */
+  std::vector<ebpf::USDT> (*init_usdt_probes)(pid_t h2o_pid);
+} h2o_tracer_t;
+
+/*
  * Creates an HTTP tracer.
  */
 h2o_tracer_t *create_http_tracer(void);

--- a/h2olog.h
+++ b/h2olog.h
@@ -29,19 +29,21 @@
 extern const char *HTTP_BPF;
 extern const char *QUIC_BPF;
 
+typedef struct st_h2o_tracer_t {
+  /*
+   * Handles an incoming BPF event.
+   */
+  void (*handle_event)(void *cpu, void *data, int len);
+} h2o_tracer_t;
 /*
- * Callback function pointer for the BPF event handler.
+
+ * Creates an HTTP tracer.
  */
-typedef void (*bpf_cb)(void *cpu, void *data, int len);
+h2o_tracer_t *create_http_tracer(void);
 
 /*
- * Handles an HTTP event from BPF.
+ * Creates a QUIC tracer.
  */
-void handle_http_event(void *cpu, void *data, int len);
-
-/*
- * Handles a QUIC event from BPF.
- */
-void handle_quic_event(void *cpu, void *data, int len);
+h2o_tracer_t *create_quic_tracer(void);
 
 #endif

--- a/http.cc
+++ b/http.cc
@@ -26,8 +26,15 @@ static void handle_event(void *cpu, void *data, int len) {
   printf("unimplemented\n");
 }
 
+static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
+  // Unimplemented
+  std::vector<ebpf::USDT> vec;
+  return vec;
+}
+
 h2o_tracer_t *create_http_tracer(void) {
   h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
   tracer->handle_event = handle_event;
+  tracer->init_usdt_probes = init_usdt_probes;
   return tracer;
 }

--- a/http.cc
+++ b/http.cc
@@ -22,6 +22,12 @@
 
 #include "h2olog.h"
 
-void handle_http_event(void *cpu, void *data, int len) {
+static void handle_event(void *cpu, void *data, int len) {
   printf("unimplemented\n");
+}
+
+h2o_tracer_t *create_http_tracer(void) {
+  h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
+  tracer->handle_event = handle_event;
+  return tracer;
 }

--- a/quic.cc
+++ b/quic.cc
@@ -48,7 +48,13 @@ struct quic_event_t {
   uint64_t at;
 };
 
-void handle_quic_event(void *cpu, void *data, int len) {
+static void handle_event(void *cpu, void *data, int len) {
   struct quic_event_t *ev = (quic_event_t*)data;
   printf("time: %" PRIu64 "\n", ev->at);
+}
+
+h2o_tracer_t *create_quic_tracer(void) {
+  h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
+  tracer->handle_event = handle_event;
+  return tracer;
 }

--- a/quic.cc
+++ b/quic.cc
@@ -55,8 +55,8 @@ static void handle_event(void *cpu, void *data, int len) {
 
 static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
   std::vector<ebpf::USDT> vec;
-  vec.push_back(ebpf::USDT("", h2o_pid, "quicly", "accept", "trace_quicly__accept"));
-  vec.push_back(ebpf::USDT("", h2o_pid, "quicly", "crypto_handshake", "trace_quicly__crypto_handshake"));
+  vec.push_back(ebpf::USDT(h2o_pid, "quicly", "accept", "trace_quicly__accept"));
+  vec.push_back(ebpf::USDT(h2o_pid, "quicly", "crypto_handshake", "trace_quicly__crypto_handshake"));
   return vec;
 }
 

--- a/quic.cc
+++ b/quic.cc
@@ -53,8 +53,16 @@ static void handle_event(void *cpu, void *data, int len) {
   printf("time: %" PRIu64 "\n", ev->at);
 }
 
+static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
+  std::vector<ebpf::USDT> vec;
+  vec.push_back(ebpf::USDT("", h2o_pid, "quicly", "accept", "trace_quicly__accept"));
+  vec.push_back(ebpf::USDT("", h2o_pid, "quicly", "crypto_handshake", "trace_quicly__crypto_handshake"));
+  return vec;
+}
+
 h2o_tracer_t *create_quic_tracer(void) {
   h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
   tracer->handle_event = handle_event;
+  tracer->init_usdt_probes = init_usdt_probes;
   return tracer;
 }


### PR DESCRIPTION
Implement an intermediate tracer representation in C, so that we can cleanly implement multiple tracers (e.g. http and quic).