### PR TITLE
Add an API to return the code for BCC to compile

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
   ebpf::BPF *bpf = new ebpf::BPF();
   std::vector<ebpf::USDT> probes = tracer->init_usdt_probes(h2o_pid);
 
-  ebpf::StatusTuple ret = bpf->init(QUIC_BPF, {}, probes);
+  ebpf::StatusTuple ret = bpf->init(tracer->bpf_text(), {}, probes);
   if (!ret.ok()) {
     std::cerr << "init: " << ret.msg() << std::endl;
     return EXIT_FAILURE;

--- a/h2olog.h
+++ b/h2olog.h
@@ -27,9 +27,6 @@
 #include <bcc/BPF.h>
 #include <vector>
 
-extern const char *HTTP_BPF;
-extern const char *QUIC_BPF;
-
 typedef struct st_h2o_tracer_t {
   /*
    * Handles an incoming BPF event.
@@ -40,6 +37,11 @@ typedef struct st_h2o_tracer_t {
    * Returns a vector of relevant USDT probes.
    */
   std::vector<ebpf::USDT> (*init_usdt_probes)(pid_t h2o_pid);
+
+  /*
+   * Returns the code to be compiled into BPF bytecode.
+   */
+  const char *(*bpf_text)(void);
 } h2o_tracer_t;
 
 /*

--- a/http.cc
+++ b/http.cc
@@ -32,9 +32,14 @@ static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
   return vec;
 }
 
+static const char *bpf_text(void) {
+  return "unimplemented";
+}
+
 h2o_tracer_t *create_http_tracer(void) {
   h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
   tracer->handle_event = handle_event;
   tracer->init_usdt_probes = init_usdt_probes;
+  tracer->bpf_text = bpf_text;
   return tracer;
 }

--- a/quic.cc
+++ b/quic.cc
@@ -60,9 +60,14 @@ static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
   return vec;
 }
 
+static const char *bpf_text(void) {
+  return QUIC_BPF;
+}
+
 h2o_tracer_t *create_quic_tracer(void) {
   h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
   tracer->handle_event = handle_event;
   tracer->init_usdt_probes = init_usdt_probes;
+  tracer->bpf_text = bpf_text;
   return tracer;
 }


### PR DESCRIPTION
There's no need for an extern constant anymore. It's nicer to add an API to the Tracer.