### PR TITLE
Keep the coding style consistent with H2O

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# requires clang-format >= 3.6
+BasedOnStyle: "LLVM"
+IndentWidth: 4
+ColumnLimit: 132
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None
+SortIncludes: false

--- a/h2olog.cc
+++ b/h2olog.cc
@@ -28,68 +28,70 @@
 #define VERSION "0.1.0"
 #define POLL_TIMEOUT 100
 
-static void usage(void) {
-  printf("h2olog (%s)\n", VERSION);
-  printf("-p PID of the H2O server\n");
-  printf("-h Print this help and exit\n");
-  return;
+static void usage(void)
+{
+    printf("h2olog (%s)\n", VERSION);
+    printf("-p PID of the H2O server\n");
+    printf("-h Print this help and exit\n");
+    return;
 }
 
-int main(int argc, char **argv) {
-  h2o_tracer_t *tracer;
-  if (argc > 1 && strcmp(argv[1], "quic") == 0) {
-    tracer = create_quic_tracer();
-    --argc;
-    ++argv;
-  } else {
-    tracer = create_http_tracer();
-  }
-
-  int c;
-  pid_t h2o_pid = -1;
-  while ((c = getopt(argc, argv, "hvp:t:s:dP:")) != -1) {
-    switch(c) {
-    case 'p':
-      h2o_pid = atoi(optarg);
-      break;
-    case 'h':
-      usage();
-      exit(EXIT_SUCCESS);
+int main(int argc, char **argv)
+{
+    h2o_tracer_t *tracer;
+    if (argc > 1 && strcmp(argv[1], "quic") == 0) {
+        tracer = create_quic_tracer();
+        --argc;
+        ++argv;
+    } else {
+        tracer = create_http_tracer();
     }
-  }
 
-  if (h2o_pid == -1) {
-    fprintf(stderr, "Error: -p option is missing\n");
-    exit(EXIT_FAILURE);
-  }
-
-  ebpf::BPF *bpf = new ebpf::BPF();
-  std::vector<ebpf::USDT> probes = tracer->init_usdt_probes(h2o_pid);
-
-  ebpf::StatusTuple ret = bpf->init(tracer->bpf_text(), {}, probes);
-  if (!ret.ok()) {
-    std::cerr << "init: " << ret.msg() << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  for (auto &probe : probes) {
-    ret = bpf->attach_usdt(probe);
-    if (ret.code() != 0) {
-      std::cerr << "attach_usdt: " << ret.msg() << std::endl;
-      return EXIT_FAILURE;
+    int c;
+    pid_t h2o_pid = -1;
+    while ((c = getopt(argc, argv, "hvp:t:s:dP:")) != -1) {
+        switch (c) {
+        case 'p':
+            h2o_pid = atoi(optarg);
+            break;
+        case 'h':
+            usage();
+            exit(EXIT_SUCCESS);
+        }
     }
-  }
 
-  ret = bpf->open_perf_buffer("events", tracer->handle_event);
-  if (!ret.ok()) {
-    std::cerr << "open_perf_buffer: " << ret.msg() << std::endl;
-    return EXIT_FAILURE;
-  }
+    if (h2o_pid == -1) {
+        fprintf(stderr, "Error: -p option is missing\n");
+        exit(EXIT_FAILURE);
+    }
 
-  ebpf::BPFPerfBuffer *perf_buffer = bpf->get_perf_buffer("events");
-  if (perf_buffer)
-    while (true)
-      perf_buffer->poll(POLL_TIMEOUT);
+    ebpf::BPF *bpf = new ebpf::BPF();
+    std::vector<ebpf::USDT> probes = tracer->init_usdt_probes(h2o_pid);
 
-  return 0;
+    ebpf::StatusTuple ret = bpf->init(tracer->bpf_text(), {}, probes);
+    if (!ret.ok()) {
+        std::cerr << "init: " << ret.msg() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    for (auto &probe : probes) {
+        ret = bpf->attach_usdt(probe);
+        if (ret.code() != 0) {
+            std::cerr << "attach_usdt: " << ret.msg() << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
+    ret = bpf->open_perf_buffer("events", tracer->handle_event);
+    if (!ret.ok()) {
+        std::cerr << "open_perf_buffer: " << ret.msg() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    ebpf::BPFPerfBuffer *perf_buffer = bpf->get_perf_buffer("events");
+    if (perf_buffer)
+        while (true)
+            perf_buffer->poll(POLL_TIMEOUT);
+
+    return 0;
 }

--- a/h2olog.h
+++ b/h2olog.h
@@ -28,20 +28,20 @@
 #include <vector>
 
 typedef struct st_h2o_tracer_t {
-  /*
-   * Handles an incoming BPF event.
-   */
-  void (*handle_event)(void *cpu, void *data, int len);
+    /*
+     * Handles an incoming BPF event.
+     */
+    void (*handle_event)(void *cpu, void *data, int len);
 
-  /*
-   * Returns a vector of relevant USDT probes.
-   */
-  std::vector<ebpf::USDT> (*init_usdt_probes)(pid_t h2o_pid);
+    /*
+     * Returns a vector of relevant USDT probes.
+     */
+    std::vector<ebpf::USDT> (*init_usdt_probes)(pid_t h2o_pid);
 
-  /*
-   * Returns the code to be compiled into BPF bytecode.
-   */
-  const char *(*bpf_text)(void);
+    /*
+     * Returns the code to be compiled into BPF bytecode.
+     */
+    const char *(*bpf_text)(void);
 } h2o_tracer_t;
 
 /*

--- a/http.cc
+++ b/http.cc
@@ -22,24 +22,28 @@
 
 #include "h2olog.h"
 
-static void handle_event(void *cpu, void *data, int len) {
-  printf("unimplemented\n");
+static void handle_event(void *cpu, void *data, int len)
+{
+    printf("unimplemented\n");
 }
 
-static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
-  // Unimplemented
-  std::vector<ebpf::USDT> vec;
-  return vec;
+static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid)
+{
+    // Unimplemented
+    std::vector<ebpf::USDT> vec;
+    return vec;
 }
 
-static const char *bpf_text(void) {
-  return "unimplemented";
+static const char *bpf_text(void)
+{
+    return "unimplemented";
 }
 
-h2o_tracer_t *create_http_tracer(void) {
-  h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
-  tracer->handle_event = handle_event;
-  tracer->init_usdt_probes = init_usdt_probes;
-  tracer->bpf_text = bpf_text;
-  return tracer;
+h2o_tracer_t *create_http_tracer(void)
+{
+    h2o_tracer_t *tracer = (h2o_tracer_t *)malloc(sizeof(tracer));
+    tracer->handle_event = handle_event;
+    tracer->init_usdt_probes = init_usdt_probes;
+    tracer->bpf_text = bpf_text;
+    return tracer;
 }

--- a/quic.cc
+++ b/quic.cc
@@ -45,29 +45,33 @@ int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
 )";
 
 struct quic_event_t {
-  uint64_t at;
+    uint64_t at;
 };
 
-static void handle_event(void *cpu, void *data, int len) {
-  struct quic_event_t *ev = (quic_event_t*)data;
-  printf("time: %" PRIu64 "\n", ev->at);
+static void handle_event(void *cpu, void *data, int len)
+{
+    struct quic_event_t *ev = (quic_event_t *)data;
+    printf("time: %" PRIu64 "\n", ev->at);
 }
 
-static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid) {
-  std::vector<ebpf::USDT> vec;
-  vec.push_back(ebpf::USDT(h2o_pid, "quicly", "accept", "trace_quicly__accept"));
-  vec.push_back(ebpf::USDT(h2o_pid, "quicly", "crypto_handshake", "trace_quicly__crypto_handshake"));
-  return vec;
+static std::vector<ebpf::USDT> init_usdt_probes(pid_t h2o_pid)
+{
+    std::vector<ebpf::USDT> vec;
+    vec.push_back(ebpf::USDT(h2o_pid, "quicly", "accept", "trace_quicly__accept"));
+    vec.push_back(ebpf::USDT(h2o_pid, "quicly", "crypto_handshake", "trace_quicly__crypto_handshake"));
+    return vec;
 }
 
-static const char *bpf_text(void) {
-  return QUIC_BPF;
+static const char *bpf_text(void)
+{
+    return QUIC_BPF;
 }
 
-h2o_tracer_t *create_quic_tracer(void) {
-  h2o_tracer_t *tracer = (h2o_tracer_t*)malloc(sizeof(tracer));
-  tracer->handle_event = handle_event;
-  tracer->init_usdt_probes = init_usdt_probes;
-  tracer->bpf_text = bpf_text;
-  return tracer;
+h2o_tracer_t *create_quic_tracer(void)
+{
+    h2o_tracer_t *tracer = (h2o_tracer_t *)malloc(sizeof(tracer));
+    tracer->handle_event = handle_event;
+    tracer->init_usdt_probes = init_usdt_probes;
+    tracer->bpf_text = bpf_text;
+    return tracer;
 }


### PR DESCRIPTION
Add a `.clang-format` file as suggested by @syohex. The file content is identical to what H2O uses. This should help our goal of some day moving h2olog to the H2O repository.