### PR TITLE
Fix for quictrace-adapter

### DIFF
--- a/json.cc
+++ b/json.cc
@@ -1,5 +1,6 @@
 #include "json.h"
 #include <cinttypes>
+#include <cctype>
 
 using namespace std;
 
@@ -30,7 +31,12 @@ static void json_write_str_value(FILE *out, const char *str)
             fprintf(out, "\\t");
             break;
         default:
-            fputc(*str, out);
+            if (isprint(*str)) {
+                fputc(*str, out);
+            } else {
+                auto u8 = static_cast<uint8_t>(*str);
+                fprintf(out, "\\u%04x", u8);
+            }
             break;
         }
         str++;

--- a/misc/gen-bpf.py
+++ b/misc/gen-bpf.py
@@ -55,10 +55,11 @@ h2o_allow_probes = set([
     "h2o:send_response_header",
 ])
 
-# mapping from proves.d's to quic-trace's:
+# convert field names for compatibility with:
+# https://github.com/h2o/quicly/blob/master/quictrace-adapter.py
 rename_map = {
     "at": "time",
-    "master_id": "master_conn_id",
+    "master_id": "conn",
 }
 
 re_flags = re.X | re.M | re.S


### PR DESCRIPTION
To make it work with quicly's quictrace-adapter. I haven't tried `quic-trace` itself yet but `quictrace-adapter.py` shows something successfully.

related: https://github.com/h2o/quicly/pull/318 https://github.com/google/quic-trace

## How to process logs with quictrace-adapter

```
$ h2olog quic -p ... -o log.jsonl
$ python QUICLY/misc/find-cdis.py log.jsonl
Connection IDs: [365690, 365691, 365692, 365693, 365694]
$ python QUICLY/misc/quictrace-adapter.py log.jsonl /dev/stdout 365692 | jq .
```