### PR TITLE
Avoid the "using" directive 

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -25,8 +25,6 @@
 
 #include "h2olog.h"
 
-using namespace std;
-
 #define VERSION "0.1.0"
 #define POLL_TIMEOUT (1000)
 

--- a/json.cc
+++ b/json.cc
@@ -2,8 +2,6 @@
 #include <cinttypes>
 #include <cctype>
 
-using namespace std;
-
 static void json_write_str_value(FILE *out, const char *str)
 {
     fputc('"', out);


### PR DESCRIPTION
As a convention, I prefer if we didn't use the "using" directive. While this project is simple enough for the pollution to not be an issue, I think it's a good habit to abide by. Google's [namespace styleguide](https://google.github.io/styleguide/cppguide.html#Namespaces) concisely covers this topic.