### PR TITLE
refactor gen-bpf.py to have main() function

### DIFF
--- a/misc/gen-bpf.py
+++ b/misc/gen-bpf.py
@@ -419,7 +419,7 @@ def main():
   try:
     (_, d_files_dir, output_file) = sys.argv
   except:
-    print("usage: %s h2o_path d_files_dir output_file" % sys.argv[0])
+    print("usage: %s d_files_dir output_file" % sys.argv[0])
     sys.exit(1)
 
   context = prepare_context(d_files_dir)


### PR DESCRIPTION
To make it available as a library, I'd like to extract all the top-level statements into `main()`.

No logic is changed.