### PR TITLE
Handle event lost; `quic` mode emits it as a "h2olog-event-lost" event

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -58,10 +58,10 @@ static void show_event_per_sec(h2o_tracer_t *tracer, time_t *t0)
             strftime(s, sizeof(s), iso8601format, &t);
 
             if (tracer->lost_count > 0) {
-                fprintf(stderr, "%s %20lu events/s (possibly lost %" PRIu64 " events)\n", s, c, tracer->lost_count);
+                fprintf(stderr, "%s %20" PRIu64 " events/s (possibly lost %" PRIu64 " events)\n", s, c, tracer->lost_count);
                 tracer->lost_count = 0;
             } else {
-                fprintf(stderr, "%s %20lu events/s\n", s, c);
+                fprintf(stderr, "%s %20" PRIu64 " events/s\n", s, c);
             }
             tracer->count = 0;
         }

--- a/h2olog.h
+++ b/h2olog.h
@@ -39,12 +39,12 @@ struct st_h2o_tracer_t {
     /*
      * The number of events emitted in `handle_event`.
      */
-    size_t count;
+    uint64_t count;
 
     /*
      * The number of lost events. It is reset periodically.
      */
-    size_t lost_count;
+    uint64_t lost_count;
 
     /*
      * Handles an incoming BPF event.

--- a/h2olog.h
+++ b/h2olog.h
@@ -27,21 +27,34 @@
 #include <vector>
 #include <bcc/BPF.h>
 
-typedef struct st_h2o_tracer_t {
+struct st_h2o_tracer_t;
+typedef struct st_h2o_tracer_t h2o_tracer_t;
+
+struct st_h2o_tracer_t {
     /*
      * Where to output the results. Defaults to `stdout`.
      */
-    std::FILE *out;
+    FILE *out;
 
     /*
-     * The number of events emitted  in `handle_event`.
+     * The number of events emitted in `handle_event`.
      */
-    std::size_t count;
+    size_t count;
+
+    /*
+     * The number of lost events. It is reset periodically.
+     */
+    size_t lost_count;
 
     /*
      * Handles an incoming BPF event.
      */
-    void (*handle_event)(void *context, void *data, int len);
+    void (*handle_event)(h2o_tracer_t *tracer, const void *data, int len);
+
+    /*
+     * Handles an event data lost.
+     */
+    void (*handle_lost)(h2o_tracer_t *tracer, uint64_t lost);
 
     /*
      * Returns a vector of relevant USDT probes.
@@ -52,7 +65,7 @@ typedef struct st_h2o_tracer_t {
      * Returns the code to be compiled into BPF bytecode.
      */
     const char *(*bpf_text)(void);
-} h2o_tracer_t;
+};
 
 /*
  * Initialize an HTTP tracer.

--- a/misc/gen-bpf.py
+++ b/misc/gen-bpf.py
@@ -308,10 +308,7 @@ std::vector<ebpf::USDT> quic_init_usdt_probes(pid_t pid) {
 
   handle_event_func = r"""
 static
-void quic_handle_event(void *context, void *data, int data_len) {
-  h2o_tracer_t *tracer = static_cast<h2o_tracer_t*>(context);
-  tracer->count++;
-
+void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
   FILE *out = tracer->out;
 
   const quic_event_t *event = static_cast<const quic_event_t*>(data);
@@ -401,13 +398,17 @@ static uint64_t time_milliseconds()
 %s
 %s
 
-static
-const char *quic_bpf_ext() {
+static void quic_handle_lost(h2o_tracer_t *tracer, uint64_t lost) {
+  fprintf(tracer->out, "{\"type\":\"h2olog-event-lost\",\"time\":%%" PRIu64 ",\"lost\":%%" PRIu64 "}\n", time_milliseconds(), lost);
+}
+
+static const char *quic_bpf_ext() {
   return bpf_text;
 }
 
 void init_quic_tracer(h2o_tracer_t * tracer) {
   tracer->handle_event = quic_handle_event;
+  tracer->handle_lost = quic_handle_lost;
   tracer->init_usdt_probes = quic_init_usdt_probes;
   tracer->bpf_text = quic_bpf_ext;
 }


### PR DESCRIPTION
* `h2olog` emits "possibly lost %d events" to stderr (almost same as the default behavior)
* `h2olog quic` emits `{"type":"h2olog-event-lost","time":%d,"lost":%d}` for event lost
