### PR TITLE
Tiny optimizations

### DIFF
--- a/json.cc
+++ b/json.cc
@@ -46,13 +46,17 @@ static void json_write_str_value(FILE *out, const char *str)
     fputc('"', out);
 }
 
+static void json_write_name_value(FILE *out, const char *name)
+{
+    fprintf(out, "\"%s\":", name);
+}
+
 void json_write_pair(FILE *out, bool comma, const char *name, const char *value)
 {
     if (comma) {
         fputc(',', out);
     }
-    json_write_str_value(out, name);
-    fputc(':', out);
+    json_write_name_value(out, name);
     json_write_str_value(out, value);
 }
 
@@ -61,8 +65,7 @@ void json_write_pair(FILE *out, bool comma, const char *name, const void *value,
     if (comma) {
         fputc(',', out);
     }
-    json_write_str_value(out, name);
-    fputc(':', out);
+    json_write_name_value(out, name);
     fputc('"', out);
     const uint8_t *bin = static_cast<const uint8_t *>(value);
     for (size_t i = 0; i < len; i++) {
@@ -87,8 +90,8 @@ void json_write_pair(FILE *out, bool comma, const char *name, const int64_t valu
     if (comma) {
         fputc(',', out);
     }
-    json_write_str_value(out, name);
-    fprintf(out, ":%" PRId64, value);
+    json_write_name_value(out, name);
+    fprintf(out, "%" PRId64, value);
 }
 
 void json_write_pair(FILE *out, bool comma, const char *name, const uint64_t value)
@@ -96,6 +99,6 @@ void json_write_pair(FILE *out, bool comma, const char *name, const uint64_t val
     if (comma) {
         fputc(',', out);
     }
-    json_write_str_value(out, name);
-    fprintf(out, ":%" PRIu64, value);
+    json_write_name_value(out, name);
+    fprintf(out, "%" PRIu64, value);
 }

--- a/json.cc
+++ b/json.cc
@@ -1,5 +1,8 @@
 #include "json.h"
-#include <cinttypes>
+#include <string.h>
+#include <inttypes.h>
+
+#define FPUTS_LIT(s, out) fwrite(s, 1, strlen(s), out)
 
 static bool json_need_escape(char c)
 {
@@ -12,25 +15,25 @@ static void json_write_str_value(FILE *out, const char *str)
     while (*str) {
         switch (*str) {
         case '\"':
-            fprintf(out, "\\\"");
+            FPUTS_LIT("\\\"", out);
             break;
         case '\\':
-            fprintf(out, "\\\\");
+            FPUTS_LIT("\\\\", out);
             break;
         case '\b':
-            fprintf(out, "\\b");
+            FPUTS_LIT("\\b", out);
             break;
         case '\f':
-            fprintf(out, "\\f");
+            FPUTS_LIT("\\f", out);
             break;
         case '\n':
-            fprintf(out, "\\n");
+            FPUTS_LIT("\\n", out);
             break;
         case '\r':
-            fprintf(out, "\\r");
+            FPUTS_LIT("\\r", out);
             break;
         case '\t':
-            fprintf(out, "\\t");
+            FPUTS_LIT("\\t", out);
             break;
         default:
             if (!json_need_escape(*str)) {
@@ -46,28 +49,31 @@ static void json_write_str_value(FILE *out, const char *str)
     fputc('"', out);
 }
 
-static void json_write_name_value(FILE *out, const char *name)
+static void json_write_name_value(FILE *out, const char *name, size_t name_len)
 {
-    fprintf(out, "\"%s\":", name);
+    fputc('"', out);
+    fwrite(name, 1, name_len, out);
+    fputc('"', out);
+    fputc(':', out);
 }
 
-void json_write_pair_n(FILE *out, const char *name, const char *value)
+void json_write_pair_n(FILE *out, const char *name, size_t name_len, const char *value)
 {
-    json_write_name_value(out, name);
+    json_write_name_value(out, name, name_len);
     json_write_str_value(out, value);
 }
 
-void json_write_pair_c(FILE *out, const char *name, const char *value)
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, const char *value)
 {
     fputc(',', out);
-    json_write_name_value(out, name);
+    json_write_name_value(out, name, name_len);
     json_write_str_value(out, value);
 }
 
-void json_write_pair_c(FILE *out, const char *name, const void *value, size_t len)
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, const void *value, size_t len)
 {
     fputc(',', out);
-    json_write_name_value(out, name);
+    json_write_name_value(out, name, name_len);
     fputc('"', out);
     const uint8_t *bin = static_cast<const uint8_t *>(value);
     for (size_t i = 0; i < len; i++) {
@@ -77,26 +83,26 @@ void json_write_pair_c(FILE *out, const char *name, const void *value, size_t le
     fputc('"', out);
 }
 
-void json_write_pair_c(FILE *out, const char *name, const int32_t value)
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, int32_t value)
 {
-    json_write_pair_c(out, name, (int64_t)value);
+    json_write_pair_c(out, name, name_len, static_cast<int64_t>(value));
 }
 
-void json_write_pair_c(FILE *out, const char *name, const uint32_t value)
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, uint32_t value)
 {
-    json_write_pair_c(out, name, (uint64_t)value);
+    json_write_pair_c(out, name, name_len, static_cast<uint64_t>(value));
 }
 
-void json_write_pair_c(FILE *out, const char *name, const int64_t value)
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, int64_t value)
 {
     fputc(',', out);
-    json_write_name_value(out, name);
+    json_write_name_value(out, name, name_len);
     fprintf(out, "%" PRId64, value);
 }
 
-void json_write_pair_c(FILE *out, const char *name, const uint64_t value)
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, uint64_t value)
 {
     fputc(',', out);
-    json_write_name_value(out, name);
+    json_write_name_value(out, name, name_len);
     fprintf(out, "%" PRIu64, value);
 }

--- a/json.cc
+++ b/json.cc
@@ -51,20 +51,22 @@ static void json_write_name_value(FILE *out, const char *name)
     fprintf(out, "\"%s\":", name);
 }
 
-void json_write_pair(FILE *out, bool comma, const char *name, const char *value)
+void json_write_pair_n(FILE *out, const char *name, const char *value)
 {
-    if (comma) {
-        fputc(',', out);
-    }
     json_write_name_value(out, name);
     json_write_str_value(out, value);
 }
 
-void json_write_pair(FILE *out, bool comma, const char *name, const void *value, size_t len)
+void json_write_pair_c(FILE *out, const char *name, const char *value)
 {
-    if (comma) {
-        fputc(',', out);
-    }
+    fputc(',', out);
+    json_write_name_value(out, name);
+    json_write_str_value(out, value);
+}
+
+void json_write_pair_c(FILE *out, const char *name, const void *value, size_t len)
+{
+    fputc(',', out);
     json_write_name_value(out, name);
     fputc('"', out);
     const uint8_t *bin = static_cast<const uint8_t *>(value);
@@ -75,30 +77,26 @@ void json_write_pair(FILE *out, bool comma, const char *name, const void *value,
     fputc('"', out);
 }
 
-void json_write_pair(FILE *out, bool comma, const char *name, const int32_t value)
+void json_write_pair_c(FILE *out, const char *name, const int32_t value)
 {
-    json_write_pair(out, comma, name, (int64_t)value);
+    json_write_pair_c(out, name, (int64_t)value);
 }
 
-void json_write_pair(FILE *out, bool comma, const char *name, const uint32_t value)
+void json_write_pair_c(FILE *out, const char *name, const uint32_t value)
 {
-    json_write_pair(out, comma, name, (uint64_t)value);
+    json_write_pair_c(out, name, (uint64_t)value);
 }
 
-void json_write_pair(FILE *out, bool comma, const char *name, const int64_t value)
+void json_write_pair_c(FILE *out, const char *name, const int64_t value)
 {
-    if (comma) {
-        fputc(',', out);
-    }
+    fputc(',', out);
     json_write_name_value(out, name);
     fprintf(out, "%" PRId64, value);
 }
 
-void json_write_pair(FILE *out, bool comma, const char *name, const uint64_t value)
+void json_write_pair_c(FILE *out, const char *name, const uint64_t value)
 {
-    if (comma) {
-        fputc(',', out);
-    }
+    fputc(',', out);
     json_write_name_value(out, name);
     fprintf(out, "%" PRIu64, value);
 }

--- a/json.cc
+++ b/json.cc
@@ -1,6 +1,10 @@
 #include "json.h"
 #include <cinttypes>
-#include <cctype>
+
+static bool json_need_escape(char c)
+{
+    return static_cast<unsigned char>(c) < 0x20 || c == 0x7f;
+}
 
 static void json_write_str_value(FILE *out, const char *str)
 {
@@ -29,7 +33,7 @@ static void json_write_str_value(FILE *out, const char *str)
             fprintf(out, "\\t");
             break;
         default:
-            if (isprint(*str)) {
+            if (!json_need_escape(*str)) {
                 fputc(*str, out);
             } else {
                 auto u8 = static_cast<uint8_t>(*str);

--- a/json.h
+++ b/json.h
@@ -7,13 +7,13 @@
 // "_n" suffix means "with no heading comma"
 // "_c" suffix means "with a heading comma"
 
-void json_write_pair_n(std::FILE *out, const char *name, const char *value);
-void json_write_pair_c(std::FILE *out, const char *name, const char *value);
+void json_write_pair_n(std::FILE *out, const char *name, size_t name_len, const char *value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const char *value);
 
-void json_write_pair_c(std::FILE *out, const char *name, const void *value, std::size_t len);
-void json_write_pair_c(std::FILE *out, const char *name, const std::int64_t value);
-void json_write_pair_c(std::FILE *out, const char *name, const std::uint64_t value);
-void json_write_pair_c(std::FILE *out, const char *name, const std::int32_t value);
-void json_write_pair_c(std::FILE *out, const char *name, const std::uint32_t value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const void *value, std::size_t len);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::int64_t value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::uint64_t value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::int32_t value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::uint32_t value);
 
 #endif

--- a/json.h
+++ b/json.h
@@ -4,11 +4,16 @@
 #include <cstdio>
 #include <cstdint>
 
-void json_write_pair(std::FILE *out, bool comma, const char *name, const char *value);
-void json_write_pair(std::FILE *out, bool comma, const char *name, const void *value, std::size_t len);
-void json_write_pair(std::FILE *out, bool comma, const char *name, const std::int64_t value);
-void json_write_pair(std::FILE *out, bool comma, const char *name, const std::uint64_t value);
-void json_write_pair(std::FILE *out, bool comma, const char *name, const std::int32_t value);
-void json_write_pair(std::FILE *out, bool comma, const char *name, const std::uint32_t value);
+// "_n" suffix means "with no heading comma"
+// "_c" suffix means "with a heading comma"
+
+void json_write_pair_n(std::FILE *out, const char *name, const char *value);
+void json_write_pair_c(std::FILE *out, const char *name, const char *value);
+
+void json_write_pair_c(std::FILE *out, const char *name, const void *value, std::size_t len);
+void json_write_pair_c(std::FILE *out, const char *name, const std::int64_t value);
+void json_write_pair_c(std::FILE *out, const char *name, const std::uint64_t value);
+void json_write_pair_c(std::FILE *out, const char *name, const std::int32_t value);
+void json_write_pair_c(std::FILE *out, const char *name, const std::uint32_t value);
 
 #endif

--- a/misc/gen-bpf.py
+++ b/misc/gen-bpf.py
@@ -331,7 +331,7 @@ void quic_handle_event(void *context, void *data, int data_len) {
 
     handle_event_func += "  case %s: { // %s\n" % (
         metadata['id'], fully_specified_probe_name)
-    handle_event_func += '    json_write_pair(out, false, "type", "%s");\n' % probe_name.replace("_", "-")
+    handle_event_func += '    json_write_pair_n(out, "type", "%s");\n' % probe_name.replace("_", "-")
 
     for field_name, field_type in flat_args_map.items():
       if block_field_set and field_name in block_field_set:
@@ -339,7 +339,7 @@ void quic_handle_event(void *context, void *data, int data_len) {
       json_field_name = rename_map.get(field_name, field_name).replace("_", "-")
       event_t_name = "%s.%s" % (probe_name, field_name)
       if not is_bin_type(field_type):
-        handle_event_func += '    json_write_pair(out, true, "%s", event->%s);\n' % (
+        handle_event_func += '    json_write_pair_c(out, "%s", event->%s);\n' % (
             json_field_name, event_t_name)
       else:  # bin type (it should have the correspinding length arg)
         len_names = set([field_name + "_len", "len"])
@@ -349,14 +349,14 @@ void quic_handle_event(void *context, void *data, int data_len) {
             len_event_t_name = "%s.%s" % (probe_name, n)
 
         # A string might be truncated in STRLEN
-        handle_event_func += '    json_write_pair(out, true, "%s", event->%s, (event->%s < STR_LEN ? event->%s : STR_LEN));\n' % (
+        handle_event_func += '    json_write_pair_c(out, "%s", event->%s, (event->%s < STR_LEN ? event->%s : STR_LEN));\n' % (
             json_field_name, event_t_name, len_event_t_name, len_event_t_name)
 
     if metadata["provider"] == "h2o":
       if probe_name != "h3_accept":
-        handle_event_func += '    json_write_pair(out, true, "master_conn_id", event->%s.master_id);\n' % (
+        handle_event_func += '    json_write_pair_c(out, "conn", event->%s.master_id);\n' % (
             probe_name)
-      handle_event_func += '    json_write_pair(out, true, "time", time_milliseconds());\n'
+      handle_event_func += '    json_write_pair_c(out, "time", time_milliseconds());\n'
 
     handle_event_func += "    break;\n"
     handle_event_func += "  }\n"


### PR DESCRIPTION
* Avoid using `isprint()`; it is even theoretically wrong because it's JSON.
* Avoid trying to escape JSON name values; also avoid too many `fputc()`
* Avoid using `printf()` family unless necessary
* Prefer `fwrite()` to reduce buffer size checking inside stdio

Thanks to @kazuho for his advice.