### PR TITLE
fix a debug message that read outside of buffers

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -81,7 +81,7 @@ static void show_process(pid_t pid)
     }
     size_t nread = fread(cmdline, 1, sizeof(cmdline), f);
     fclose(f);
-    if (nread <= 0) {
+    if (nread == 0) {
         fprintf(stderr, "Error: failed to read from %s: %s\n", proc_file, strerror(errno));
         exit(EXIT_FAILURE);
     }

--- a/h2olog.cc
+++ b/h2olog.cc
@@ -81,6 +81,7 @@ static void show_process(pid_t pid)
     }
     size_t nread = fread(cmdline, 1, sizeof(cmdline), f);
     fclose(f);
+    nread--; // skip trailing nul
     for (size_t i = 0; i < nread; i++) {
         if (cmdline[i] == '\0') {
             cmdline[i] = ' ';

--- a/h2olog.cc
+++ b/h2olog.cc
@@ -81,6 +81,10 @@ static void show_process(pid_t pid)
     }
     size_t nread = fread(cmdline, 1, sizeof(cmdline), f);
     fclose(f);
+    if (nread <= 0) {
+        fprintf(stderr, "Error: failed to read from %s: %s\n", proc_file, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
     nread--; // skip trailing nul
     for (size_t i = 0; i < nread; i++) {
         if (cmdline[i] == '\0') {


### PR DESCRIPTION
This function shows h2o command line like this:

```
Attaching pid=58459 (build/h2o -c examples/h2o/h2o.conf)
```

The `cmdline` is read from `/proc/{pid}/cmdline`, which is NUL-separated values, so the last trailing NUL must not be replaced to a whitespace.