### PR TITLE
Tweak the quicly-probes.d download link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ SET(SOURCE_FILES
 
 ADD_CUSTOM_COMMAND(
     OUTPUT  "${CMAKE_BINARY_DIR}/quicly-probes.d"
-    COMMAND curl -sL 'https://raw.githubusercontent.com/h2o/quicly/master/quicly-probes.d' >${CMAKE_BINARY_DIR}/quicly-probes.d
+    COMMAND curl -sL 'https://raw.githubusercontent.com/h2o/h2o/fb0d55a/deps/quicly/quicly-probes.d' >${CMAKE_BINARY_DIR}/quicly-probes.d
 )
 LIST(APPEND DTRACE_FILES "${CMAKE_BINARY_DIR}/quicly-probes.d")
 


### PR DESCRIPTION
Our CMake based build pipeline is downloading a [Quicly](https://github.com/h2o/quicly) probe definition file that's too new, even for upstream H2O. Therefore I'd like to make couple of tweaks:

- Download from H2O repo, not Quicly
- Pin the commit hash

The latter is not ideal. This will go away once we merge with the official H2O repository.