### PR TITLE
build instructions for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ For convenience, you can alternatively run the `make.sh` script.
 - CMake for generating the build files
 - Python 3 for the [code generator](https://github.com/toru/h2olog/blob/v2/misc/gen-quic-bpf.py)
 - [BCC](https://iovisor.github.io/bcc/) (>= 0.11.0) [installed](https://github.com/iovisor/bcc/blob/master/INSTALL.md) on your system
-- systemtap for Linux to enable DTrace for H2O
+- [SystemTap](https://sourceware.org/systemtap/) for DTrace shim to build H2O with DTrace support
 
-If you use Ubuntu 20.04 or later, you can install dependencies with `apt`:
+For Ubuntu 20.04 or later, you can install dependencies with:
 
 ```sh
 sudo apt install clang cmake python3 systemtap-sdt-dev libbpfcc-dev linux-headers-$(uname -r)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ For convenience, you can alternatively run the `make.sh` script.
 - CMake for generating the build files
 - Python 3 for the [code generator](https://github.com/toru/h2olog/blob/v2/misc/gen-quic-bpf.py)
 - [BCC](https://iovisor.github.io/bcc/) (>= 0.11.0) [installed](https://github.com/iovisor/bcc/blob/master/INSTALL.md) on your system
-- [SystemTap](https://sourceware.org/systemtap/) for DTrace shim to build H2O with DTrace support
 
 For Ubuntu 20.04 or later, you can install dependencies with:
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ See [Tracing QUIC events](#tracing-quic-events) for how.
 See [requirements](#requirements) for build prerequisites.
 
 ```
-$ cmake .
-$ make
-$ sudo make install
+$ cmake -H. -Bbuild
+$ make -Cbuild
+$ sudo make -Cbuild install
 ```
 
 For convenience, you can alternatively run the `make.sh` script.
@@ -24,6 +24,13 @@ For convenience, you can alternatively run the `make.sh` script.
 - CMake for generating the build files
 - Python 3 for the [code generator](https://github.com/toru/h2olog/blob/v2/misc/gen-quic-bpf.py)
 - [BCC](https://iovisor.github.io/bcc/) (>= 0.11.0) [installed](https://github.com/iovisor/bcc/blob/master/INSTALL.md) on your system
+- systemtap for Linux to enable DTrace for H2O
+
+If you use Ubuntu 20.04 or later, you can install dependencies with `apt`:
+
+```sh
+sudo apt install clang cmake python3 systemtap-sdt-dev libbpfcc-dev linux-headers-$(uname -r)
+```
 
 ### For running h2olog
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See [Tracing QUIC events](#tracing-quic-events) for how.
 See [requirements](#requirements) for build prerequisites.
 
 ```
-$ cmake -H. -Bbuild
+$ cmake -Bbuild
 $ make -Cbuild
 $ sudo make -Cbuild install
 ```


### PR DESCRIPTION
I've tested to build h2olog on Ubuntu 20.04. Fortunately, all the dependencies can be installed by `apt` 👏 