### PR TITLE
let h2olog exit when the attaching h2o process exits

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -148,6 +148,13 @@ static std::string generate_header_filter_cflag(const std::vector<std::string> &
     return cflag;
 }
 
+static std::string make_pid_cflag(const char *macro_name, pid_t pid)
+{
+    char buf[256];
+    snprintf(buf, sizeof(buf), "-D%s=%d", macro_name, pid);
+    return std::string(buf);
+}
+
 static void event_cb(void *context, void *data, int len)
 {
     h2o_tracer_t *tracer = (h2o_tracer_t *)context;
@@ -237,6 +244,8 @@ int main(int argc, char **argv)
 
     std::vector<std::string> cflags;
 
+    cflags.push_back(make_pid_cflag("TARGET_PID", h2o_pid));
+
     if (!response_header_filters.empty()) {
         cflags.push_back(generate_header_filter_cflag(response_header_filters));
     }
@@ -249,6 +258,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: init: %s\n", ret.msg().c_str());
         return EXIT_FAILURE;
     }
+
+    bpf->attach_tracepoint("sched:sched_process_exit", "trace_sched_process_exit");
 
     for (auto &probe : probes) {
         ret = bpf->attach_usdt(probe);

--- a/h2olog.cc
+++ b/h2olog.cc
@@ -242,9 +242,9 @@ int main(int argc, char **argv)
         tracer.out = stdout;
     }
 
-    std::vector<std::string> cflags;
-
-    cflags.push_back(make_pid_cflag("TARGET_PID", h2o_pid));
+    std::vector<std::string> cflags({
+        make_pid_cflag("H2OLOG_H2O_PID", h2o_pid),
+    });
 
     if (!response_header_filters.empty()) {
         cflags.push_back(generate_header_filter_cflag(response_header_filters));

--- a/http.cc
+++ b/http.cc
@@ -23,13 +23,16 @@
 #include "h2olog.h"
 
 const char *HTTP_BPF = R"(
+#include <linux/sched.h>
+
 #define MAX_HDR_LEN 128
 
 enum {
   HTTP_EVENT_RECEIVE_REQ,
   HTTP_EVENT_RECEIVE_REQ_HDR,
   HTTP_EVENT_SEND_RESP,
-  HTTP_EVENT_SEND_RESP_HDR
+  HTTP_EVENT_SEND_RESP_HDR,
+  SCHED_PROCESS_EXIT,
 };
 
 typedef struct  st_http_event_t {
@@ -49,6 +52,16 @@ typedef struct  st_http_event_t {
 } http_event_t;
 
 BPF_PERF_OUTPUT(events);
+
+int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
+  const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
+  if (task->tgid != TARGET_PID) {
+    return 0;
+  }
+  http_event_t ev = { .type = SCHED_PROCESS_EXIT };
+  events.perf_submit(ctx, &ev, sizeof(ev));
+  return 0;
+}
 
 int trace_receive_request(struct pt_regs *ctx) {
   http_event_t ev = { .type = HTTP_EVENT_RECEIVE_REQ };
@@ -102,7 +115,13 @@ int trace_send_response_header(struct pt_regs *ctx) {
 #define MAX_HDR_LEN 128
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-enum { HTTP_EVENT_RECEIVE_REQ, HTTP_EVENT_RECEIVE_REQ_HDR, HTTP_EVENT_SEND_RESP, HTTP_EVENT_SEND_RESP_HDR };
+enum {
+    HTTP_EVENT_RECEIVE_REQ,
+    HTTP_EVENT_RECEIVE_REQ_HDR,
+    HTTP_EVENT_SEND_RESP,
+    HTTP_EVENT_SEND_RESP_HDR,
+    SCHED_PROCESS_EXIT,
+};
 
 typedef struct st_http_event_t {
     uint8_t type;
@@ -140,6 +159,9 @@ static void handle_event(h2o_tracer_t *tracer, const void *data, int len)
         const char *label = (ev->type == HTTP_EVENT_RECEIVE_REQ_HDR) ? "RxHeader" : "TxHeader";
         fprintf(out, "%" PRIu64 " %" PRIu64 " %s   %.*s %.*s\n", ev->conn_id, ev->req_id, label, n_len, ev->header.name, v_len,
                 ev->header.value);
+    } break;
+    case SCHED_PROCESS_EXIT: {
+        exit(0);
     } break;
     default:
         fprintf(out, "unknown event: %u\n", ev->type);

--- a/http.cc
+++ b/http.cc
@@ -55,7 +55,7 @@ BPF_PERF_OUTPUT(events);
 
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
-  if (task->tgid != TARGET_PID) {
+  if (task->tgid != H2OLOG_H2O_PID) {
     return 0;
   }
   http_event_t ev = { .type = SCHED_PROCESS_EXIT };

--- a/misc/gen-quic-bpf.py
+++ b/misc/gen-quic-bpf.py
@@ -297,7 +297,7 @@ BPF_HASH(h2o_to_quicly_conn, u64, u32);
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
-  if (task->tgid != TARGET_PID) {
+  if (task->tgid != H2OLOG_H2O_PID) {
     return 0;
   }
   struct quic_event_t ev = { .id = 1 };

--- a/misc/gen-quic-bpf.py
+++ b/misc/gen-quic-bpf.py
@@ -240,7 +240,7 @@ int %s(struct pt_regs *ctx) {
 def prepare_context(d_files_dir):
   st_map = parse_c_struct(data_types_h)
   context = {
-      "id": 0,
+      "id": 1, # 1 is used for sched:sched_process_exit
       "probe_metadata": OrderedDict(),
       "st_map": st_map,
   }
@@ -284,6 +284,8 @@ struct quic_event_t {
   """
 
   bpf = r"""
+#include <linux/sched.h>
+
 #define STR_LEN 64
 %s
 %s
@@ -291,6 +293,18 @@ BPF_PERF_OUTPUT(events);
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
+
+// tracepoint sched:sched_process_exit
+int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
+  const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
+  if (task->tgid != TARGET_PID) {
+    return 0;
+  }
+  struct quic_event_t ev = { .id = 1 };
+  events.perf_submit(ctx, &ev, sizeof(ev));
+  return 0;
+}
+
 """ % (data_types_h.read_text(), event_t_decl)
 
   usdt_def = """
@@ -316,6 +330,10 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
   FILE *out = tracer->out;
 
   const quic_event_t *event = static_cast<const quic_event_t*>(data);
+
+  if (event->id == 1) { // sched:sched_process_exit
+    exit(0);
+  }
 
   // output JSON
   fprintf(out, "{");


### PR DESCRIPTION
This feature is inevitable to correctly follow the attaching `h2o` restarting.

The tracepoint `sched:sched_process_exit` used in this PR is what [exitsnoop](https://github.com/iovisor/bcc/blob/master/tools/exitsnoop.py) uses.