### PR TITLE
Revert "let h2olog exit when the attaching h2o process exits"

### DIFF
--- a/h2olog.cc
+++ b/h2olog.cc
@@ -148,13 +148,6 @@ static std::string generate_header_filter_cflag(const std::vector<std::string> &
     return cflag;
 }
 
-static std::string make_pid_cflag(const char *macro_name, pid_t pid)
-{
-    char buf[256];
-    snprintf(buf, sizeof(buf), "-D%s=%d", macro_name, pid);
-    return std::string(buf);
-}
-
 static void event_cb(void *context, void *data, int len)
 {
     h2o_tracer_t *tracer = (h2o_tracer_t *)context;
@@ -242,9 +235,7 @@ int main(int argc, char **argv)
         tracer.out = stdout;
     }
 
-    std::vector<std::string> cflags({
-        make_pid_cflag("H2OLOG_H2O_PID", h2o_pid),
-    });
+    std::vector<std::string> cflags;
 
     if (!response_header_filters.empty()) {
         cflags.push_back(generate_header_filter_cflag(response_header_filters));
@@ -258,8 +249,6 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: init: %s\n", ret.msg().c_str());
         return EXIT_FAILURE;
     }
-
-    bpf->attach_tracepoint("sched:sched_process_exit", "trace_sched_process_exit");
 
     for (auto &probe : probes) {
         ret = bpf->attach_usdt(probe);

--- a/http.cc
+++ b/http.cc
@@ -23,16 +23,13 @@
 #include "h2olog.h"
 
 const char *HTTP_BPF = R"(
-#include <linux/sched.h>
-
 #define MAX_HDR_LEN 128
 
 enum {
   HTTP_EVENT_RECEIVE_REQ,
   HTTP_EVENT_RECEIVE_REQ_HDR,
   HTTP_EVENT_SEND_RESP,
-  HTTP_EVENT_SEND_RESP_HDR,
-  SCHED_PROCESS_EXIT,
+  HTTP_EVENT_SEND_RESP_HDR
 };
 
 typedef struct  st_http_event_t {
@@ -52,16 +49,6 @@ typedef struct  st_http_event_t {
 } http_event_t;
 
 BPF_PERF_OUTPUT(events);
-
-int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
-  const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
-  if (task->tgid != H2OLOG_H2O_PID) {
-    return 0;
-  }
-  http_event_t ev = { .type = SCHED_PROCESS_EXIT };
-  events.perf_submit(ctx, &ev, sizeof(ev));
-  return 0;
-}
 
 int trace_receive_request(struct pt_regs *ctx) {
   http_event_t ev = { .type = HTTP_EVENT_RECEIVE_REQ };
@@ -115,13 +102,7 @@ int trace_send_response_header(struct pt_regs *ctx) {
 #define MAX_HDR_LEN 128
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-enum {
-    HTTP_EVENT_RECEIVE_REQ,
-    HTTP_EVENT_RECEIVE_REQ_HDR,
-    HTTP_EVENT_SEND_RESP,
-    HTTP_EVENT_SEND_RESP_HDR,
-    SCHED_PROCESS_EXIT,
-};
+enum { HTTP_EVENT_RECEIVE_REQ, HTTP_EVENT_RECEIVE_REQ_HDR, HTTP_EVENT_SEND_RESP, HTTP_EVENT_SEND_RESP_HDR };
 
 typedef struct st_http_event_t {
     uint8_t type;
@@ -159,9 +140,6 @@ static void handle_event(h2o_tracer_t *tracer, const void *data, int len)
         const char *label = (ev->type == HTTP_EVENT_RECEIVE_REQ_HDR) ? "RxHeader" : "TxHeader";
         fprintf(out, "%" PRIu64 " %" PRIu64 " %s   %.*s %.*s\n", ev->conn_id, ev->req_id, label, n_len, ev->header.name, v_len,
                 ev->header.value);
-    } break;
-    case SCHED_PROCESS_EXIT: {
-        exit(0);
     } break;
     default:
         fprintf(out, "unknown event: %u\n", ev->type);


### PR DESCRIPTION
Reverts toru/h2olog#73 because **it does not work** as expected. Probably it is triggered when a thread exits?

I need to find another way.`bpftrace` uses `/proc/:pid/status` https://github.com/iovisor/bpftrace/blob/cb86948874d1e6e984f1b783bb13b26c7d1ec914/src/procmon.cpp#L75-L114 but I'm not sure it is the best way to do so.