### PR TITLE
let h2olog exit when the attaching h2o process exits (again)

### DIFF
--- a/generated-quic.cc
+++ b/generated-quic.cc
@@ -15,6 +15,8 @@
 // BPF modules written in C
 const char *bpf_text = R"(
 
+#include <linux/sched.h>
+
 #define STR_LEN 64
 /*
  * Copyright (c) 2019-2020 Fastly, Inc., Toru Maesaka, Goro Fuji
@@ -427,10 +429,24 @@ BPF_PERF_OUTPUT(events);
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
+
+// tracepoint sched:sched_process_exit
+int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
+  const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
+  pid_t h2o_pid = task->tgid;
+  pid_t h2o_tid = task->pid;
+  if (!(h2o_pid == H2OLOG_H2O_PID && h2o_tid == H2OLOG_H2O_PID)) {
+    return 0;
+  }
+  struct quic_event_t ev = { .id = 1 };
+  events.perf_submit(ctx, &ev, sizeof(ev));
+  return 0;
+}
+
 // quicly:connect
 int trace_quicly__connect(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 1 };
+  struct quic_event_t event = { .id = 2 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -450,7 +466,7 @@ int trace_quicly__connect(struct pt_regs *ctx) {
 // quicly:accept
 int trace_quicly__accept(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 2 };
+  struct quic_event_t event = { .id = 3 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -475,7 +491,7 @@ int trace_quicly__accept(struct pt_regs *ctx) {
 // quicly:free
 int trace_quicly__free(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 3 };
+  struct quic_event_t event = { .id = 4 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -493,7 +509,7 @@ int trace_quicly__free(struct pt_regs *ctx) {
 // quicly:send
 int trace_quicly__send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 4 };
+  struct quic_event_t event = { .id = 5 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -516,7 +532,7 @@ int trace_quicly__send(struct pt_regs *ctx) {
 // quicly:receive
 int trace_quicly__receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 5 };
+  struct quic_event_t event = { .id = 6 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -540,7 +556,7 @@ int trace_quicly__receive(struct pt_regs *ctx) {
 // quicly:version_switch
 int trace_quicly__version_switch(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 6 };
+  struct quic_event_t event = { .id = 7 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -560,7 +576,7 @@ int trace_quicly__version_switch(struct pt_regs *ctx) {
 // quicly:idle_timeout
 int trace_quicly__idle_timeout(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 7 };
+  struct quic_event_t event = { .id = 8 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -578,7 +594,7 @@ int trace_quicly__idle_timeout(struct pt_regs *ctx) {
 // quicly:stateless_reset_receive
 int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 8 };
+  struct quic_event_t event = { .id = 9 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -596,7 +612,7 @@ int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
 // quicly:crypto_decrypt
 int trace_quicly__crypto_decrypt(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 9 };
+  struct quic_event_t event = { .id = 10 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -619,7 +635,7 @@ int trace_quicly__crypto_decrypt(struct pt_regs *ctx) {
 // quicly:crypto_handshake
 int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 10 };
+  struct quic_event_t event = { .id = 11 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -639,7 +655,7 @@ int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
 // quicly:crypto_update_secret
 int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 11 };
+  struct quic_event_t event = { .id = 12 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -665,7 +681,7 @@ int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
 // quicly:crypto_send_key_update
 int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 12 };
+  struct quic_event_t event = { .id = 13 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -686,7 +702,7 @@ int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
 // quicly:crypto_send_key_update_confirmed
 int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 13 };
+  struct quic_event_t event = { .id = 14 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -706,7 +722,7 @@ int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
 // quicly:crypto_receive_key_update
 int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 14 };
+  struct quic_event_t event = { .id = 15 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -727,7 +743,7 @@ int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
 // quicly:crypto_receive_key_update_prepare
 int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 15 };
+  struct quic_event_t event = { .id = 16 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -748,7 +764,7 @@ int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
 // quicly:packet_prepare
 int trace_quicly__packet_prepare(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 16 };
+  struct quic_event_t event = { .id = 17 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -771,7 +787,7 @@ int trace_quicly__packet_prepare(struct pt_regs *ctx) {
 // quicly:packet_commit
 int trace_quicly__packet_commit(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 17 };
+  struct quic_event_t event = { .id = 18 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -795,7 +811,7 @@ int trace_quicly__packet_commit(struct pt_regs *ctx) {
 // quicly:packet_acked
 int trace_quicly__packet_acked(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 18 };
+  struct quic_event_t event = { .id = 19 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -817,7 +833,7 @@ int trace_quicly__packet_acked(struct pt_regs *ctx) {
 // quicly:packet_lost
 int trace_quicly__packet_lost(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 19 };
+  struct quic_event_t event = { .id = 20 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -837,7 +853,7 @@ int trace_quicly__packet_lost(struct pt_regs *ctx) {
 // quicly:pto
 int trace_quicly__pto(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 20 };
+  struct quic_event_t event = { .id = 21 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -861,7 +877,7 @@ int trace_quicly__pto(struct pt_regs *ctx) {
 // quicly:cc_ack_received
 int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 21 };
+  struct quic_event_t event = { .id = 22 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -887,7 +903,7 @@ int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
 // quicly:cc_congestion
 int trace_quicly__cc_congestion(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 22 };
+  struct quic_event_t event = { .id = 23 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -911,7 +927,7 @@ int trace_quicly__cc_congestion(struct pt_regs *ctx) {
 // quicly:transport_close_send
 int trace_quicly__transport_close_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 23 };
+  struct quic_event_t event = { .id = 24 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -936,7 +952,7 @@ int trace_quicly__transport_close_send(struct pt_regs *ctx) {
 // quicly:transport_close_receive
 int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 24 };
+  struct quic_event_t event = { .id = 25 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -961,7 +977,7 @@ int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
 // quicly:application_close_send
 int trace_quicly__application_close_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 25 };
+  struct quic_event_t event = { .id = 26 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -984,7 +1000,7 @@ int trace_quicly__application_close_send(struct pt_regs *ctx) {
 // quicly:application_close_receive
 int trace_quicly__application_close_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 26 };
+  struct quic_event_t event = { .id = 27 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1007,7 +1023,7 @@ int trace_quicly__application_close_receive(struct pt_regs *ctx) {
 // quicly:stream_send
 int trace_quicly__stream_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 27 };
+  struct quic_event_t event = { .id = 28 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1036,7 +1052,7 @@ int trace_quicly__stream_send(struct pt_regs *ctx) {
 // quicly:stream_receive
 int trace_quicly__stream_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 28 };
+  struct quic_event_t event = { .id = 29 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1063,7 +1079,7 @@ int trace_quicly__stream_receive(struct pt_regs *ctx) {
 // quicly:stream_acked
 int trace_quicly__stream_acked(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 29 };
+  struct quic_event_t event = { .id = 30 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1087,7 +1103,7 @@ int trace_quicly__stream_acked(struct pt_regs *ctx) {
 // quicly:stream_lost
 int trace_quicly__stream_lost(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 30 };
+  struct quic_event_t event = { .id = 31 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1111,7 +1127,7 @@ int trace_quicly__stream_lost(struct pt_regs *ctx) {
 // quicly:max_data_send
 int trace_quicly__max_data_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 31 };
+  struct quic_event_t event = { .id = 32 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1131,7 +1147,7 @@ int trace_quicly__max_data_send(struct pt_regs *ctx) {
 // quicly:max_data_receive
 int trace_quicly__max_data_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 32 };
+  struct quic_event_t event = { .id = 33 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1151,7 +1167,7 @@ int trace_quicly__max_data_receive(struct pt_regs *ctx) {
 // quicly:max_streams_send
 int trace_quicly__max_streams_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 33 };
+  struct quic_event_t event = { .id = 34 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1173,7 +1189,7 @@ int trace_quicly__max_streams_send(struct pt_regs *ctx) {
 // quicly:max_streams_receive
 int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 34 };
+  struct quic_event_t event = { .id = 35 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1195,7 +1211,7 @@ int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
 // quicly:max_stream_data_send
 int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 35 };
+  struct quic_event_t event = { .id = 36 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1220,7 +1236,7 @@ int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
 // quicly:max_stream_data_receive
 int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 36 };
+  struct quic_event_t event = { .id = 37 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1242,7 +1258,7 @@ int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
 // quicly:new_token_send
 int trace_quicly__new_token_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 37 };
+  struct quic_event_t event = { .id = 38 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1267,7 +1283,7 @@ int trace_quicly__new_token_send(struct pt_regs *ctx) {
 // quicly:new_token_acked
 int trace_quicly__new_token_acked(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 38 };
+  struct quic_event_t event = { .id = 39 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1287,7 +1303,7 @@ int trace_quicly__new_token_acked(struct pt_regs *ctx) {
 // quicly:new_token_receive
 int trace_quicly__new_token_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 39 };
+  struct quic_event_t event = { .id = 40 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1310,7 +1326,7 @@ int trace_quicly__new_token_receive(struct pt_regs *ctx) {
 // quicly:handshake_done_send
 int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 40 };
+  struct quic_event_t event = { .id = 41 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1328,7 +1344,7 @@ int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
 // quicly:handshake_done_receive
 int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 41 };
+  struct quic_event_t event = { .id = 42 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1346,7 +1362,7 @@ int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
 // quicly:streams_blocked_send
 int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 42 };
+  struct quic_event_t event = { .id = 43 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1368,7 +1384,7 @@ int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
 // quicly:streams_blocked_receive
 int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 43 };
+  struct quic_event_t event = { .id = 44 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1390,7 +1406,7 @@ int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
 // quicly:data_blocked_receive
 int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 44 };
+  struct quic_event_t event = { .id = 45 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1410,7 +1426,7 @@ int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
 // quicly:stream_data_blocked_receive
 int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 45 };
+  struct quic_event_t event = { .id = 46 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1432,7 +1448,7 @@ int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
 // quicly:quictrace_sent
 int trace_quicly__quictrace_sent(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 46 };
+  struct quic_event_t event = { .id = 47 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1456,7 +1472,7 @@ int trace_quicly__quictrace_sent(struct pt_regs *ctx) {
 // quicly:quictrace_recv
 int trace_quicly__quictrace_recv(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 47 };
+  struct quic_event_t event = { .id = 48 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1476,7 +1492,7 @@ int trace_quicly__quictrace_recv(struct pt_regs *ctx) {
 // quicly:quictrace_send_stream
 int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 48 };
+  struct quic_event_t event = { .id = 49 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1505,7 +1521,7 @@ int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
 // quicly:quictrace_recv_stream
 int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 49 };
+  struct quic_event_t event = { .id = 50 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1531,7 +1547,7 @@ int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
 // quicly:quictrace_recv_ack
 int trace_quicly__quictrace_recv_ack(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 50 };
+  struct quic_event_t event = { .id = 51 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1553,7 +1569,7 @@ int trace_quicly__quictrace_recv_ack(struct pt_regs *ctx) {
 // quicly:quictrace_recv_ack_delay
 int trace_quicly__quictrace_recv_ack_delay(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 51 };
+  struct quic_event_t event = { .id = 52 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1573,7 +1589,7 @@ int trace_quicly__quictrace_recv_ack_delay(struct pt_regs *ctx) {
 // quicly:quictrace_lost
 int trace_quicly__quictrace_lost(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 52 };
+  struct quic_event_t event = { .id = 53 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1593,7 +1609,7 @@ int trace_quicly__quictrace_lost(struct pt_regs *ctx) {
 // quicly:quictrace_cc_ack
 int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 53 };
+  struct quic_event_t event = { .id = 54 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1623,7 +1639,7 @@ int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
 // quicly:quictrace_cc_lost
 int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 54 };
+  struct quic_event_t event = { .id = 55 };
 
   // struct st_quicly_conn_t * conn
   struct st_quicly_conn_t  conn = {};
@@ -1653,7 +1669,7 @@ int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
 // h2o:h3_accept
 int trace_h2o__h3_accept(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 59 };
+  struct quic_event_t event = { .id = 60 };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3_accept.conn_id);
@@ -1674,7 +1690,7 @@ int trace_h2o__h3_accept(struct pt_regs *ctx) {
 // h2o:h3_close
 int trace_h2o__h3_close(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 60 };
+  struct quic_event_t event = { .id = 61 };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3_close.conn_id);
@@ -1695,7 +1711,7 @@ int trace_h2o__h3_close(struct pt_regs *ctx) {
 // h2o:send_response_header
 int trace_h2o__send_response_header(struct pt_regs *ctx) {
   void *buf = NULL;
-  struct quic_event_t event = { .id = 69 };
+  struct quic_event_t event = { .id = 70 };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.send_response_header.conn_id);
@@ -2161,31 +2177,35 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
 
   const quic_event_t *event = static_cast<const quic_event_t*>(data);
 
+  if (event->id == 1) { // sched:sched_process_exit
+    exit(0);
+  }
+
   // output JSON
   fprintf(out, "{");
 
   switch (event->id) {
-  case 1: { // quicly:connect
+  case 2: { // quicly:connect
     json_write_pair_n(out, STR_LIT("type"), "connect");
     json_write_pair_c(out, STR_LIT("conn"), event->connect.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->connect.at);
     json_write_pair_c(out, STR_LIT("version"), event->connect.version);
     break;
   }
-  case 2: { // quicly:accept
+  case 3: { // quicly:accept
     json_write_pair_n(out, STR_LIT("type"), "accept");
     json_write_pair_c(out, STR_LIT("conn"), event->accept.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->accept.at);
     json_write_pair_c(out, STR_LIT("dcid"), event->accept.dcid);
     break;
   }
-  case 3: { // quicly:free
+  case 4: { // quicly:free
     json_write_pair_n(out, STR_LIT("type"), "free");
     json_write_pair_c(out, STR_LIT("conn"), event->free.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->free.at);
     break;
   }
-  case 4: { // quicly:send
+  case 5: { // quicly:send
     json_write_pair_n(out, STR_LIT("type"), "send");
     json_write_pair_c(out, STR_LIT("conn"), event->send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->send.at);
@@ -2193,7 +2213,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("dcid"), event->send.dcid);
     break;
   }
-  case 5: { // quicly:receive
+  case 6: { // quicly:receive
     json_write_pair_n(out, STR_LIT("type"), "receive");
     json_write_pair_c(out, STR_LIT("conn"), event->receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->receive.at);
@@ -2201,26 +2221,26 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("bytes-len"), event->receive.num_bytes);
     break;
   }
-  case 6: { // quicly:version_switch
+  case 7: { // quicly:version_switch
     json_write_pair_n(out, STR_LIT("type"), "version-switch");
     json_write_pair_c(out, STR_LIT("conn"), event->version_switch.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->version_switch.at);
     json_write_pair_c(out, STR_LIT("new-version"), event->version_switch.new_version);
     break;
   }
-  case 7: { // quicly:idle_timeout
+  case 8: { // quicly:idle_timeout
     json_write_pair_n(out, STR_LIT("type"), "idle-timeout");
     json_write_pair_c(out, STR_LIT("conn"), event->idle_timeout.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->idle_timeout.at);
     break;
   }
-  case 8: { // quicly:stateless_reset_receive
+  case 9: { // quicly:stateless_reset_receive
     json_write_pair_n(out, STR_LIT("type"), "stateless-reset-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->stateless_reset_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->stateless_reset_receive.at);
     break;
   }
-  case 9: { // quicly:crypto_decrypt
+  case 10: { // quicly:crypto_decrypt
     json_write_pair_n(out, STR_LIT("type"), "crypto-decrypt");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_decrypt.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_decrypt.at);
@@ -2228,14 +2248,14 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("decrypted-len"), event->crypto_decrypt.decrypted_len);
     break;
   }
-  case 10: { // quicly:crypto_handshake
+  case 11: { // quicly:crypto_handshake
     json_write_pair_n(out, STR_LIT("type"), "crypto-handshake");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_handshake.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_handshake.at);
     json_write_pair_c(out, STR_LIT("ret"), event->crypto_handshake.ret);
     break;
   }
-  case 11: { // quicly:crypto_update_secret
+  case 12: { // quicly:crypto_update_secret
     json_write_pair_n(out, STR_LIT("type"), "crypto-update-secret");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_update_secret.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_update_secret.at);
@@ -2244,35 +2264,35 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("label"), event->crypto_update_secret.label);
     break;
   }
-  case 12: { // quicly:crypto_send_key_update
+  case 13: { // quicly:crypto_send_key_update
     json_write_pair_n(out, STR_LIT("type"), "crypto-send-key-update");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_send_key_update.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_send_key_update.at);
     json_write_pair_c(out, STR_LIT("phase"), event->crypto_send_key_update.phase);
     break;
   }
-  case 13: { // quicly:crypto_send_key_update_confirmed
+  case 14: { // quicly:crypto_send_key_update_confirmed
     json_write_pair_n(out, STR_LIT("type"), "crypto-send-key-update-confirmed");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_send_key_update_confirmed.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_send_key_update_confirmed.at);
     json_write_pair_c(out, STR_LIT("next-pn"), event->crypto_send_key_update_confirmed.next_pn);
     break;
   }
-  case 14: { // quicly:crypto_receive_key_update
+  case 15: { // quicly:crypto_receive_key_update
     json_write_pair_n(out, STR_LIT("type"), "crypto-receive-key-update");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_receive_key_update.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_receive_key_update.at);
     json_write_pair_c(out, STR_LIT("phase"), event->crypto_receive_key_update.phase);
     break;
   }
-  case 15: { // quicly:crypto_receive_key_update_prepare
+  case 16: { // quicly:crypto_receive_key_update_prepare
     json_write_pair_n(out, STR_LIT("type"), "crypto-receive-key-update-prepare");
     json_write_pair_c(out, STR_LIT("conn"), event->crypto_receive_key_update_prepare.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->crypto_receive_key_update_prepare.at);
     json_write_pair_c(out, STR_LIT("phase"), event->crypto_receive_key_update_prepare.phase);
     break;
   }
-  case 16: { // quicly:packet_prepare
+  case 17: { // quicly:packet_prepare
     json_write_pair_n(out, STR_LIT("type"), "packet-prepare");
     json_write_pair_c(out, STR_LIT("conn"), event->packet_prepare.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->packet_prepare.at);
@@ -2280,7 +2300,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("dcid"), event->packet_prepare.dcid);
     break;
   }
-  case 17: { // quicly:packet_commit
+  case 18: { // quicly:packet_commit
     json_write_pair_n(out, STR_LIT("type"), "packet-commit");
     json_write_pair_c(out, STR_LIT("conn"), event->packet_commit.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->packet_commit.at);
@@ -2289,7 +2309,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("ack-only"), event->packet_commit.ack_only);
     break;
   }
-  case 18: { // quicly:packet_acked
+  case 19: { // quicly:packet_acked
     json_write_pair_n(out, STR_LIT("type"), "packet-acked");
     json_write_pair_c(out, STR_LIT("conn"), event->packet_acked.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->packet_acked.at);
@@ -2297,14 +2317,14 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("newly-acked"), event->packet_acked.newly_acked);
     break;
   }
-  case 19: { // quicly:packet_lost
+  case 20: { // quicly:packet_lost
     json_write_pair_n(out, STR_LIT("type"), "packet-lost");
     json_write_pair_c(out, STR_LIT("conn"), event->packet_lost.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->packet_lost.at);
     json_write_pair_c(out, STR_LIT("pn"), event->packet_lost.pn);
     break;
   }
-  case 20: { // quicly:pto
+  case 21: { // quicly:pto
     json_write_pair_n(out, STR_LIT("type"), "pto");
     json_write_pair_c(out, STR_LIT("conn"), event->pto.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->pto.at);
@@ -2313,7 +2333,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("pto-count"), event->pto.pto_count);
     break;
   }
-  case 21: { // quicly:cc_ack_received
+  case 22: { // quicly:cc_ack_received
     json_write_pair_n(out, STR_LIT("type"), "cc-ack-received");
     json_write_pair_c(out, STR_LIT("conn"), event->cc_ack_received.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->cc_ack_received.at);
@@ -2323,7 +2343,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("inflight"), event->cc_ack_received.inflight);
     break;
   }
-  case 22: { // quicly:cc_congestion
+  case 23: { // quicly:cc_congestion
     json_write_pair_n(out, STR_LIT("type"), "cc-congestion");
     json_write_pair_c(out, STR_LIT("conn"), event->cc_congestion.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->cc_congestion.at);
@@ -2332,7 +2352,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("cwnd"), event->cc_congestion.cwnd);
     break;
   }
-  case 23: { // quicly:transport_close_send
+  case 24: { // quicly:transport_close_send
     json_write_pair_n(out, STR_LIT("type"), "transport-close-send");
     json_write_pair_c(out, STR_LIT("conn"), event->transport_close_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->transport_close_send.at);
@@ -2341,7 +2361,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("reason-phrase"), event->transport_close_send.reason_phrase);
     break;
   }
-  case 24: { // quicly:transport_close_receive
+  case 25: { // quicly:transport_close_receive
     json_write_pair_n(out, STR_LIT("type"), "transport-close-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->transport_close_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->transport_close_receive.at);
@@ -2350,7 +2370,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("reason-phrase"), event->transport_close_receive.reason_phrase);
     break;
   }
-  case 25: { // quicly:application_close_send
+  case 26: { // quicly:application_close_send
     json_write_pair_n(out, STR_LIT("type"), "application-close-send");
     json_write_pair_c(out, STR_LIT("conn"), event->application_close_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->application_close_send.at);
@@ -2358,7 +2378,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("reason-phrase"), event->application_close_send.reason_phrase);
     break;
   }
-  case 26: { // quicly:application_close_receive
+  case 27: { // quicly:application_close_receive
     json_write_pair_n(out, STR_LIT("type"), "application-close-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->application_close_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->application_close_receive.at);
@@ -2366,7 +2386,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("reason-phrase"), event->application_close_receive.reason_phrase);
     break;
   }
-  case 27: { // quicly:stream_send
+  case 28: { // quicly:stream_send
     json_write_pair_n(out, STR_LIT("type"), "stream-send");
     json_write_pair_c(out, STR_LIT("conn"), event->stream_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->stream_send.at);
@@ -2376,7 +2396,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("is-fin"), event->stream_send.is_fin);
     break;
   }
-  case 28: { // quicly:stream_receive
+  case 29: { // quicly:stream_receive
     json_write_pair_n(out, STR_LIT("type"), "stream-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->stream_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->stream_receive.at);
@@ -2385,7 +2405,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("len"), event->stream_receive.len);
     break;
   }
-  case 29: { // quicly:stream_acked
+  case 30: { // quicly:stream_acked
     json_write_pair_n(out, STR_LIT("type"), "stream-acked");
     json_write_pair_c(out, STR_LIT("conn"), event->stream_acked.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->stream_acked.at);
@@ -2394,7 +2414,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("len"), event->stream_acked.len);
     break;
   }
-  case 30: { // quicly:stream_lost
+  case 31: { // quicly:stream_lost
     json_write_pair_n(out, STR_LIT("type"), "stream-lost");
     json_write_pair_c(out, STR_LIT("conn"), event->stream_lost.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->stream_lost.at);
@@ -2403,21 +2423,21 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("len"), event->stream_lost.len);
     break;
   }
-  case 31: { // quicly:max_data_send
+  case 32: { // quicly:max_data_send
     json_write_pair_n(out, STR_LIT("type"), "max-data-send");
     json_write_pair_c(out, STR_LIT("conn"), event->max_data_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->max_data_send.at);
     json_write_pair_c(out, STR_LIT("limit"), event->max_data_send.limit);
     break;
   }
-  case 32: { // quicly:max_data_receive
+  case 33: { // quicly:max_data_receive
     json_write_pair_n(out, STR_LIT("type"), "max-data-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->max_data_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->max_data_receive.at);
     json_write_pair_c(out, STR_LIT("limit"), event->max_data_receive.limit);
     break;
   }
-  case 33: { // quicly:max_streams_send
+  case 34: { // quicly:max_streams_send
     json_write_pair_n(out, STR_LIT("type"), "max-streams-send");
     json_write_pair_c(out, STR_LIT("conn"), event->max_streams_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->max_streams_send.at);
@@ -2425,7 +2445,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("is-unidirectional"), event->max_streams_send.is_unidirectional);
     break;
   }
-  case 34: { // quicly:max_streams_receive
+  case 35: { // quicly:max_streams_receive
     json_write_pair_n(out, STR_LIT("type"), "max-streams-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->max_streams_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->max_streams_receive.at);
@@ -2433,7 +2453,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("is-unidirectional"), event->max_streams_receive.is_unidirectional);
     break;
   }
-  case 35: { // quicly:max_stream_data_send
+  case 36: { // quicly:max_stream_data_send
     json_write_pair_n(out, STR_LIT("type"), "max-stream-data-send");
     json_write_pair_c(out, STR_LIT("conn"), event->max_stream_data_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->max_stream_data_send.at);
@@ -2441,7 +2461,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("limit"), event->max_stream_data_send.limit);
     break;
   }
-  case 36: { // quicly:max_stream_data_receive
+  case 37: { // quicly:max_stream_data_receive
     json_write_pair_n(out, STR_LIT("type"), "max-stream-data-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->max_stream_data_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->max_stream_data_receive.at);
@@ -2449,7 +2469,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("limit"), event->max_stream_data_receive.limit);
     break;
   }
-  case 37: { // quicly:new_token_send
+  case 38: { // quicly:new_token_send
     json_write_pair_n(out, STR_LIT("type"), "new-token-send");
     json_write_pair_c(out, STR_LIT("conn"), event->new_token_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->new_token_send.at);
@@ -2458,14 +2478,14 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("generation"), event->new_token_send.generation);
     break;
   }
-  case 38: { // quicly:new_token_acked
+  case 39: { // quicly:new_token_acked
     json_write_pair_n(out, STR_LIT("type"), "new-token-acked");
     json_write_pair_c(out, STR_LIT("conn"), event->new_token_acked.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->new_token_acked.at);
     json_write_pair_c(out, STR_LIT("generation"), event->new_token_acked.generation);
     break;
   }
-  case 39: { // quicly:new_token_receive
+  case 40: { // quicly:new_token_receive
     json_write_pair_n(out, STR_LIT("type"), "new-token-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->new_token_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->new_token_receive.at);
@@ -2473,19 +2493,19 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("len"), event->new_token_receive.len);
     break;
   }
-  case 40: { // quicly:handshake_done_send
+  case 41: { // quicly:handshake_done_send
     json_write_pair_n(out, STR_LIT("type"), "handshake-done-send");
     json_write_pair_c(out, STR_LIT("conn"), event->handshake_done_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->handshake_done_send.at);
     break;
   }
-  case 41: { // quicly:handshake_done_receive
+  case 42: { // quicly:handshake_done_receive
     json_write_pair_n(out, STR_LIT("type"), "handshake-done-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->handshake_done_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->handshake_done_receive.at);
     break;
   }
-  case 42: { // quicly:streams_blocked_send
+  case 43: { // quicly:streams_blocked_send
     json_write_pair_n(out, STR_LIT("type"), "streams-blocked-send");
     json_write_pair_c(out, STR_LIT("conn"), event->streams_blocked_send.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->streams_blocked_send.at);
@@ -2493,7 +2513,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("is-unidirectional"), event->streams_blocked_send.is_unidirectional);
     break;
   }
-  case 43: { // quicly:streams_blocked_receive
+  case 44: { // quicly:streams_blocked_receive
     json_write_pair_n(out, STR_LIT("type"), "streams-blocked-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->streams_blocked_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->streams_blocked_receive.at);
@@ -2501,14 +2521,14 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("is-unidirectional"), event->streams_blocked_receive.is_unidirectional);
     break;
   }
-  case 44: { // quicly:data_blocked_receive
+  case 45: { // quicly:data_blocked_receive
     json_write_pair_n(out, STR_LIT("type"), "data-blocked-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->data_blocked_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->data_blocked_receive.at);
     json_write_pair_c(out, STR_LIT("off"), event->data_blocked_receive.off);
     break;
   }
-  case 45: { // quicly:stream_data_blocked_receive
+  case 46: { // quicly:stream_data_blocked_receive
     json_write_pair_n(out, STR_LIT("type"), "stream-data-blocked-receive");
     json_write_pair_c(out, STR_LIT("conn"), event->stream_data_blocked_receive.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->stream_data_blocked_receive.at);
@@ -2516,7 +2536,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("limit"), event->stream_data_blocked_receive.limit);
     break;
   }
-  case 46: { // quicly:quictrace_sent
+  case 47: { // quicly:quictrace_sent
     json_write_pair_n(out, STR_LIT("type"), "quictrace-sent");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_sent.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_sent.at);
@@ -2525,14 +2545,14 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("packet-type"), event->quictrace_sent.packet_type);
     break;
   }
-  case 47: { // quicly:quictrace_recv
+  case 48: { // quicly:quictrace_recv
     json_write_pair_n(out, STR_LIT("type"), "quictrace-recv");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_recv.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_recv.at);
     json_write_pair_c(out, STR_LIT("pn"), event->quictrace_recv.pn);
     break;
   }
-  case 48: { // quicly:quictrace_send_stream
+  case 49: { // quicly:quictrace_send_stream
     json_write_pair_n(out, STR_LIT("type"), "quictrace-send-stream");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_send_stream.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_send_stream.at);
@@ -2542,7 +2562,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("fin"), event->quictrace_send_stream.fin);
     break;
   }
-  case 49: { // quicly:quictrace_recv_stream
+  case 50: { // quicly:quictrace_recv_stream
     json_write_pair_n(out, STR_LIT("type"), "quictrace-recv-stream");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_recv_stream.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_recv_stream.at);
@@ -2552,7 +2572,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("fin"), event->quictrace_recv_stream.fin);
     break;
   }
-  case 50: { // quicly:quictrace_recv_ack
+  case 51: { // quicly:quictrace_recv_ack
     json_write_pair_n(out, STR_LIT("type"), "quictrace-recv-ack");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_recv_ack.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_recv_ack.at);
@@ -2560,21 +2580,21 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("ack-block-end"), event->quictrace_recv_ack.ack_block_end);
     break;
   }
-  case 51: { // quicly:quictrace_recv_ack_delay
+  case 52: { // quicly:quictrace_recv_ack_delay
     json_write_pair_n(out, STR_LIT("type"), "quictrace-recv-ack-delay");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_recv_ack_delay.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_recv_ack_delay.at);
     json_write_pair_c(out, STR_LIT("ack-delay"), event->quictrace_recv_ack_delay.ack_delay);
     break;
   }
-  case 52: { // quicly:quictrace_lost
+  case 53: { // quicly:quictrace_lost
     json_write_pair_n(out, STR_LIT("type"), "quictrace-lost");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_lost.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_lost.at);
     json_write_pair_c(out, STR_LIT("pn"), event->quictrace_lost.pn);
     break;
   }
-  case 53: { // quicly:quictrace_cc_ack
+  case 54: { // quicly:quictrace_cc_ack
     json_write_pair_n(out, STR_LIT("type"), "quictrace-cc-ack");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_cc_ack.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_cc_ack.at);
@@ -2586,7 +2606,7 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("inflight"), event->quictrace_cc_ack.inflight);
     break;
   }
-  case 54: { // quicly:quictrace_cc_lost
+  case 55: { // quicly:quictrace_cc_lost
     json_write_pair_n(out, STR_LIT("type"), "quictrace-cc-lost");
     json_write_pair_c(out, STR_LIT("conn"), event->quictrace_cc_lost.master_id);
     json_write_pair_c(out, STR_LIT("time"), event->quictrace_cc_lost.at);
@@ -2598,21 +2618,21 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
     json_write_pair_c(out, STR_LIT("inflight"), event->quictrace_cc_lost.inflight);
     break;
   }
-  case 59: { // h2o:h3_accept
+  case 60: { // h2o:h3_accept
     json_write_pair_n(out, STR_LIT("type"), "h3-accept");
     json_write_pair_c(out, STR_LIT("conn-id"), event->h3_accept.conn_id);
     json_write_pair_c(out, STR_LIT("conn"), event->h3_accept.master_id);
     json_write_pair_c(out, STR_LIT("time"), time_milliseconds());
     break;
   }
-  case 60: { // h2o:h3_close
+  case 61: { // h2o:h3_close
     json_write_pair_n(out, STR_LIT("type"), "h3-close");
     json_write_pair_c(out, STR_LIT("conn-id"), event->h3_close.conn_id);
     json_write_pair_c(out, STR_LIT("conn"), event->h3_close.master_id);
     json_write_pair_c(out, STR_LIT("time"), time_milliseconds());
     break;
   }
-  case 69: { // h2o:send_response_header
+  case 70: { // h2o:send_response_header
     json_write_pair_n(out, STR_LIT("type"), "send-response-header");
     json_write_pair_c(out, STR_LIT("conn-id"), event->send_response_header.conn_id);
     json_write_pair_c(out, STR_LIT("req-id"), event->send_response_header.req_id);

--- a/h2olog.cc
+++ b/h2olog.cc
@@ -148,6 +148,13 @@ static std::string generate_header_filter_cflag(const std::vector<std::string> &
     return cflag;
 }
 
+static std::string make_pid_cflag(const char *macro_name, pid_t pid)
+{
+    char buf[256];
+    snprintf(buf, sizeof(buf), "-D%s=%d", macro_name, pid);
+    return std::string(buf);
+}
+
 static void event_cb(void *context, void *data, int len)
 {
     h2o_tracer_t *tracer = (h2o_tracer_t *)context;
@@ -235,7 +242,9 @@ int main(int argc, char **argv)
         tracer.out = stdout;
     }
 
-    std::vector<std::string> cflags;
+    std::vector<std::string> cflags({
+        make_pid_cflag("H2OLOG_H2O_PID", h2o_pid),
+    });
 
     if (!response_header_filters.empty()) {
         cflags.push_back(generate_header_filter_cflag(response_header_filters));
@@ -249,6 +258,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: init: %s\n", ret.msg().c_str());
         return EXIT_FAILURE;
     }
+
+    bpf->attach_tracepoint("sched:sched_process_exit", "trace_sched_process_exit");
 
     for (auto &probe : probes) {
         ret = bpf->attach_usdt(probe);

--- a/http.cc
+++ b/http.cc
@@ -55,7 +55,9 @@ BPF_PERF_OUTPUT(events);
 
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
-  if (task->tgid != H2OLOG_H2O_PID) {
+  pid_t h2o_pid = task->tgid;
+  pid_t h2o_tid = task->pid;
+  if (!(h2o_pid == H2OLOG_H2O_PID && h2o_tid == H2OLOG_H2O_PID)) {
     return 0;
   }
   http_event_t ev = { .type = SCHED_PROCESS_EXIT };

--- a/http.cc
+++ b/http.cc
@@ -23,13 +23,16 @@
 #include "h2olog.h"
 
 const char *HTTP_BPF = R"(
+#include <linux/sched.h>
+
 #define MAX_HDR_LEN 128
 
 enum {
   HTTP_EVENT_RECEIVE_REQ,
   HTTP_EVENT_RECEIVE_REQ_HDR,
   HTTP_EVENT_SEND_RESP,
-  HTTP_EVENT_SEND_RESP_HDR
+  HTTP_EVENT_SEND_RESP_HDR,
+  SCHED_PROCESS_EXIT,
 };
 
 typedef struct  st_http_event_t {
@@ -49,6 +52,16 @@ typedef struct  st_http_event_t {
 } http_event_t;
 
 BPF_PERF_OUTPUT(events);
+
+int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
+  const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
+  if (task->tgid != H2OLOG_H2O_PID) {
+    return 0;
+  }
+  http_event_t ev = { .type = SCHED_PROCESS_EXIT };
+  events.perf_submit(ctx, &ev, sizeof(ev));
+  return 0;
+}
 
 int trace_receive_request(struct pt_regs *ctx) {
   http_event_t ev = { .type = HTTP_EVENT_RECEIVE_REQ };
@@ -102,7 +115,13 @@ int trace_send_response_header(struct pt_regs *ctx) {
 #define MAX_HDR_LEN 128
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-enum { HTTP_EVENT_RECEIVE_REQ, HTTP_EVENT_RECEIVE_REQ_HDR, HTTP_EVENT_SEND_RESP, HTTP_EVENT_SEND_RESP_HDR };
+enum {
+    HTTP_EVENT_RECEIVE_REQ,
+    HTTP_EVENT_RECEIVE_REQ_HDR,
+    HTTP_EVENT_SEND_RESP,
+    HTTP_EVENT_SEND_RESP_HDR,
+    SCHED_PROCESS_EXIT,
+};
 
 typedef struct st_http_event_t {
     uint8_t type;
@@ -140,6 +159,9 @@ static void handle_event(h2o_tracer_t *tracer, const void *data, int len)
         const char *label = (ev->type == HTTP_EVENT_RECEIVE_REQ_HDR) ? "RxHeader" : "TxHeader";
         fprintf(out, "%" PRIu64 " %" PRIu64 " %s   %.*s %.*s\n", ev->conn_id, ev->req_id, label, n_len, ev->header.name, v_len,
                 ev->header.value);
+    } break;
+    case SCHED_PROCESS_EXIT: {
+        exit(0);
     } break;
     default:
         fprintf(out, "unknown event: %u\n", ev->type);

--- a/misc/gen-quic-bpf.py
+++ b/misc/gen-quic-bpf.py
@@ -306,7 +306,9 @@ BPF_HASH(h2o_to_quicly_conn, u64, u32);
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
-  if (task->tgid != H2OLOG_H2O_PID) {
+  pid_t h2o_pid = task->tgid;
+  pid_t h2o_tid = task->pid;
+  if (!(h2o_pid == H2OLOG_H2O_PID && h2o_tid == H2OLOG_H2O_PID)) {
     return 0;
   }
   struct quic_event_t ev = { .id = 1 };

--- a/misc/gen-quic-bpf.py
+++ b/misc/gen-quic-bpf.py
@@ -243,7 +243,7 @@ int %s(struct pt_regs *ctx) {
 def prepare_context(d_files_dir):
   st_map = parse_c_struct(data_types_h)
   context = {
-      "id": 0,
+      "id": 1, # 1 is used for sched:sched_process_exit
       "probe_metadata": OrderedDict(),
       "st_map": st_map,
   }
@@ -293,6 +293,8 @@ struct quic_event_t {
   """
 
   bpf = r"""
+#include <linux/sched.h>
+
 #define STR_LEN 64
 %s
 %s
@@ -300,6 +302,18 @@ BPF_PERF_OUTPUT(events);
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
+
+// tracepoint sched:sched_process_exit
+int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
+  const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
+  if (task->tgid != H2OLOG_H2O_PID) {
+    return 0;
+  }
+  struct quic_event_t ev = { .id = 1 };
+  events.perf_submit(ctx, &ev, sizeof(ev));
+  return 0;
+}
+
 """ % (data_types_h.read_text(), event_t_decl)
 
   usdt_def = """
@@ -325,6 +339,10 @@ void quic_handle_event(h2o_tracer_t *tracer, const void *data, int data_len) {
   FILE *out = tracer->out;
 
   const quic_event_t *event = static_cast<const quic_event_t*>(data);
+
+  if (event->id == 1) { // sched:sched_process_exit
+    exit(0);
+  }
 
   // output JSON
   fprintf(out, "{");


### PR DESCRIPTION
Amending https://github.com/toru/h2olog/pull/73 to check if the exiting thread is the main-thread or not, assuming PID == TID is true in the main thread, as `gettid(2)` says (thanks to [syohex](https://twitter.com/syohex/status/1261217801626193921) san).

cf. https://github.com/iovisor/bcc/blob/ab54de2e4449027f2b4dccd022adc57bec4fd4eb/tools/exitsnoop.py#L124-L125

